### PR TITLE
修复中文引号匹配的 bug

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -137,7 +137,8 @@ function parseResponse(response: string) {
 
         logger.debug('message: ' + message)
         message = message.match(/\[.*(:|：).*(:|：)(.*)\]/)?.[3] ?? ''
-        message = message.match(/"(.*)"/)?.[1] ?? message
+        message = message.match(/["\u201c\u201d“”](.*)["\u201c\u201d“”]/)?.[1] ?? message;
+
         logger.debug('message: ' + message)
         if (typeof message !== 'string') {
             logger.error('Failed to parse response: ' + response)


### PR DESCRIPTION
现在中英文引号都可以匹配，如下：
![image](https://github.com/ChatLunaLab/chatluna-character/assets/120614554/556fbdf1-9cba-4206-a213-1427beabb5dc)
![image](https://github.com/ChatLunaLab/chatluna-character/assets/120614554/449d818b-5b58-443b-a532-73840e54cb9e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了聊天插件中消息提取的鲁棒性，现在可以处理包括Unicode字符在内的不同类型的引号。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->