### PR TITLE
[Fix]: Avoid false positives caused by nickname matching in mentions

### DIFF
--- a/src/plugins/filter.ts
+++ b/src/plugins/filter.ts
@@ -161,24 +161,24 @@ export async function apply(ctx: Context, config: Config) {
             appel = session.quote?.user?.id === botId
         }
 
-        const plainTextContent =
+        const isAppel = Boolean(appel)
+        const muteKeywords = currentPreset.mute_keyword ?? []
+        const forceMuteActive =
+            copyOfConfig.isForceMute && isAppel && muteKeywords.length > 0
+        const needPlainText =
             copyOfConfig.isNickname ||
             copyOfConfig.isNickNameWithContent ||
-            (copyOfConfig.isForceMute &&
-                appel &&
-                currentPreset.mute_keyword?.length > 0)
-                ? (session.elements ?? [])
-                      .filter((element) => element.type === 'text')
-                      .map((element) => element.attrs?.content ?? '')
-                      .join('')
-                : ''
+            forceMuteActive
 
-        if (
-            copyOfConfig.isForceMute &&
-            appel &&
-            currentPreset.mute_keyword?.length > 0
-        ) {
-            const needMute = currentPreset.mute_keyword.some((value) =>
+        const plainTextContent = needPlainText
+            ? (session.elements ?? [])
+                  .filter((element) => element.type === 'text')
+                  .map((element) => element.attrs?.content ?? '')
+                  .join('')
+            : ''
+
+        if (forceMuteActive) {
+            const needMute = muteKeywords.some((value) =>
                 plainTextContent.includes(value)
             )
 
@@ -191,7 +191,7 @@ export async function apply(ctx: Context, config: Config) {
         const isMute = service.isMute(session)
 
         const isDirectTrigger =
-            appel ||
+            isAppel ||
             (copyOfConfig.isNickname &&
                 currentPreset.nick_name.some((value) =>
                     plainTextContent.startsWith(value)


### PR DESCRIPTION
## Problem Description
When mentioning a user whose name contains the bot’s nickname as a substring, the bot may be triggered unintentionally.

**Reproduction Scenario:**
- Bot nickname: `jack`
- User name: `jacky`
- Message sent: `@jacky hello`
- Result: The bot is triggered unexpectedly

## Root Case
The matching logic operates on message.content, which includes tag-based markup intended for the model, rather than the plain text actually entered by the user. As a result, usernames inside <at> tags may be matched unintentionally.

## Fix
Matching is now performed on plain text extracted from the original message elements, avoiding interference from tag-based markup.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message text aggregation for filtering so mute and nickname-related conditions trigger more accurately.
  * More reliable detection of direct mentions and nickname matches.
  * Normalized caller identification to improve mention handling.
  * Refined force-mute activation so keyword-based mutes apply consistently when conditions are met.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->