### PR TITLE
fix(reply): 强制 reply tool field 提供 invoke 和 render

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { MessageCollector } from './service/message'
 import { TriggerStore } from './service/trigger'
 import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
-import type {} from '@koishijs/plugin-console'
+import type { } from '@koishijs/plugin-console'
 
 export function apply(ctx: Context, config: Config) {
     const changed = migrateConfig(config)
@@ -127,17 +127,11 @@ export const usage = `
 
 请先阅读[**此文档**](https://chatluna.chat/ecosystem/other/character.html)了解使用方式。
 
-### 26.03.09
+### 26.04.05
 
-伪装插件现已支持私聊！更新后开启相关配置即可体验，私聊预设与群聊预设通用，仅需调整少量关于 Bot 所在环境的描述。
+伪装插件新增实验性“工具调用回复”功能，详情请查看文档。
 
-注意：旧版本的预设格式（不支持消息自分割的版本）将会无效，请手动参考文档更新到最新版的预设格式。
-
-### 26.03.13
-
-对配置页面进行了重构，增强了可读性。
-
-可以迁移到新版的参数均已保留，但仍建议自行检查是否有遗漏。
+本次更新也对部分旧的 XML 格式进行了调整（如发送图片/表情包、设置触发器等），请参考最新文档对预设进行修改，避免消息发送异常。
 `
 
 export { Config } from './config'

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { MessageCollector } from './service/message'
 import { TriggerStore } from './service/trigger'
 import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
-import type { } from '@koishijs/plugin-console'
+import type {} from '@koishijs/plugin-console'
 
 export function apply(ctx: Context, config: Config) {
     const changed = migrateConfig(config)

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -527,7 +527,7 @@ function createReplyTools(
             const input = args as Record<string, unknown>
 
             for (const field of ctx.chatluna_character.getReplyToolFields()) {
-                if (field.invoke == null || input[field.name] == null) {
+                if (input[field.name] == null) {
                     continue
                 }
 
@@ -817,7 +817,7 @@ function renderReplyToolXml(
         }
 
         for (const field of fields) {
-            if (field.render == null || call.args[field.name] == null) {
+            if (call.args[field.name] == null) {
                 continue
             }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,13 +30,13 @@ export interface CharacterReplyToolField {
         session: Session,
         config: Config | GuildConfig | PrivateConfig
     ) => boolean
-    invoke?: (
+    invoke: (
         ctx: Context,
         session: Session,
         value: unknown,
         config: Config | GuildConfig | PrivateConfig
     ) => Promise<void> | void
-    render?: (
+    render: (
         ctx: Context,
         session: Session,
         value: unknown,


### PR DESCRIPTION
## 摘要
- 将 `CharacterReplyToolField` 的 `invoke`、`render` 从可选改为必填。
- 清理 `chat.ts` 中对应的空值判断，使调用逻辑与接口约束保持一致。
- 已执行 `yarn tsc --noEmit`、`yarn fast-build`，并完成本地 Koishi 同步与重启验证。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reply tool fields now require full handler implementations and are only skipped when their input is missing, enforcing consistent behavior.
* **New Features**
  * Added an experimental "tool call reply" capability for richer automated replies.
* **Documentation**
  * Updated usage notes and guidance, including adjustments for some legacy XML formats to avoid message issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->