### PR TITLE
fix(log): 隐藏 reply tool 控制结果日志

### DIFF
--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -336,6 +336,18 @@ export async function createChatLunaChain(
                                     result = output.replace(/\\n/g, '\n')
                                 }
                             }
+                            if (
+                                result === '__character_reply_progress__' ||
+                                result === '__character_reply_final__' ||
+                                (
+                                    typeof result === 'object' &&
+                                    result != null &&
+                                    'lc_direct_tool_output' in result &&
+                                    result.lc_direct_tool_output === true
+                                )
+                            ) {
+                                return
+                            }
                             const text =
                                 typeof result === 'string'
                                     ? result


### PR DESCRIPTION
## Summary
- 配合前面 `character_reply` / direct tool output 的回复链路修复，隐藏这类控制用工具结果日志。
- 不再打印 `__character_reply_progress__`、`__character_reply_final__` 和最终 direct tool output 对象，减少调试输出噪音。
- 保留其他真正有内容的工具结果日志，避免影响正常排查。
