### PR TITLE
fix(character): 保留完整上下文并收紧 reply tool 文案

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-character",
     "description": "Let the large language model play a role, disguise as a group friend",
-    "version": "0.0.208",
+    "version": "0.0.209",
     "type": "module",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,7 +95,7 @@ const commonModelConfig = Schema.object({
     maxTokens: Schema.number()
         .default(20000)
         .min(1024)
-        .max(20000)
+        .max(1000000)
         .description('使用聊天的最大 token 数'),
     enableMessageId: Schema.boolean()
         .description('向模型暴露平台消息 ID，以允许发送引用消息。')

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -547,7 +547,13 @@ function createReplyTools(
         }, {
             name: 'character_reply',
             description:
-                'Send one or more in-character reply messages and required actions. All user-visible reply content must be sent through this tool. Use real newlines in all string fields, not the literal string `\\n`. Do not manually wrap content in XML tags inside any field. Fill the structured fields directly. Do not end the turn with plain text output outside this tool.',
+                'Send one or more in-character reply messages and required ' +
+                'actions. All user-visible reply content must be sent ' +
+                'through this tool. Use real newlines in all string ' +
+                'fields, not the literal string `\\n`. Do not manually ' +
+                'wrap content in XML tags inside any field. Fill the ' +
+                'structured fields directly. Do not end the turn with ' +
+                'plain text output outside this tool.',
             returnDirect: false,
             schema: {
                 type: 'object',

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -547,13 +547,7 @@ function createReplyTools(
         }, {
             name: 'character_reply',
             description:
-                'Send one or more in-character reply messages and required ' +
-                'actions. All user-visible reply content must be sent ' +
-                'through this tool. Use real newlines in all string ' +
-                'fields, not the literal string `\\n`. Do not manually ' +
-                'wrap content in XML tags inside any field. Fill the ' +
-                'structured fields directly. Do not end the turn with ' +
-                'plain text output outside this tool.',
+                'Send one or more in-character reply messages and required actions. All user-visible reply content must be sent through this tool. Use real newlines in all string fields, not the literal string `\\n`. Do not manually wrap content in XML tags inside any field. Fill the structured fields directly. Do not end the turn with plain text output outside this tool.',
             returnDirect: false,
             schema: {
                 type: 'object',

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -547,7 +547,7 @@ function createReplyTools(
         }, {
             name: 'character_reply',
             description:
-                'Send one or more in-character reply messages and required actions. All user-visible reply content must be sent through this tool. Do not end the turn with plain text output outside this tool.',
+                'Send one or more in-character reply messages and required actions. All user-visible reply content must be sent through this tool. Use real newlines in all string fields, not the literal string `\\n`. Do not manually wrap content in XML tags inside any field. Fill the structured fields directly. Do not end the turn with plain text output outside this tool.',
             returnDirect: false,
             schema: {
                 type: 'object',

--- a/src/service/message.ts
+++ b/src/service/message.ts
@@ -1,4 +1,4 @@
-import { Context, h, Logger, Service, Session, Time } from 'koishi'
+import { Context, h, Logger, Service, Session } from 'koishi'
 import { createLogger } from 'koishi-plugin-chatluna/utils/logger'
 import { ObjectLock } from 'koishi-plugin-chatluna/utils/lock'
 import { Config } from '..'
@@ -690,7 +690,6 @@ export class MessageCollector extends Service {
         }
 
         const triggerReason = await this._addMessage(session, message, {
-            filterExpiredMessages: true,
             processImages: config
         })
 
@@ -857,7 +856,6 @@ export class MessageCollector extends Service {
         session: Session,
         message: Message,
         options?: {
-            filterExpiredMessages?: boolean
             processImages?: Config
         }
     ): Promise<string | undefined> {
@@ -882,16 +880,6 @@ export class MessageCollector extends Service {
 
             while (groupArray.length > maxMessageSize) {
                 groupArray.shift()
-            }
-
-            if (options?.filterExpiredMessages) {
-                const now = Date.now()
-                groupArray = groupArray.filter((msg) => {
-                    return (
-                        msg.timestamp == null ||
-                        msg.timestamp >= now - Time.hour
-                    )
-                })
             }
 
             if (options?.processImages) {


### PR DESCRIPTION
## Summary
- 移除消息收集阶段的一小时过期过滤，避免群组上下文在 `maxMessages` 之外被提前裁剪。
- 将 `maxTokens` 的可配置上限提高到 `1000000`，便于在高上下文模型下保留更多聊天记录。
- 收紧 `character_reply` 工具描述，明确所有字符串字段应使用真实换行，且不要在字段内容中手动包裹 XML。

## Verification
- `yarn tsc --noEmit`
- `yarn fast-build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration now supports much higher token limits (up to 1,000,000).

* **Documentation**
  * Clarified chat tool input formatting: require real newlines, avoid manual XML wrapping, and prefer populating structured fields directly.

* **Bug Fixes**
  * Disabled automatic expiration of buffered messages so older messages are no longer pruned automatically.

* **Chores**
  * Released new package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->