### PR TITLE
支持按会话配置工具调用回复字段

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-character",
     "description": "Let the large language model play a role, disguise as a group friend",
-    "version": "0.0.209",
+    "version": "0.0.210",
     "type": "module",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,6 +48,10 @@ export interface Config extends ChatLunaPlugin.Config {
 
     toolCalling: boolean
     experimentalToolCallReply: boolean
+    toolCallReplyThinkTag: boolean
+    toolCallReplyStatusTag: boolean
+    toolCallReplyNextReply: boolean
+    toolCallReplyWakeUpReply: boolean
     isForceMute: boolean
     sendStickerProbability: number
     image: boolean
@@ -109,8 +113,8 @@ const commonModelConfig = Schema.object({
         .default(true)
         .description(
             '是否在缺失历史消息时自动从支持的 API ' +
-                '（如 OneBot 及所有支持 getMessageList 的适配器）' +
-                '获取历史消息，使重启插件时可以获取刚刚的上下文'
+            '（如 OneBot 及所有支持 getMessageList 的适配器）' +
+            '获取历史消息，使重启插件时可以获取刚刚的上下文'
         )
 })
     .description('上下文')
@@ -150,39 +154,72 @@ const commonMuteConfig = Schema.object({
     .description('闭嘴')
     .collapse()
 
-const commonModelFeatureConfig = Schema.object({
-    toolCalling: Schema.boolean()
+const commonToolCallReplyConfig = Schema.object({
+    experimentalToolCallReply: Schema.boolean()
+        .default(false)
         .description(
-            '是否启用工具调用功能（可在[**这里**]' +
-                '(https://cooksleep.github.io/newapi-special-test)' +
-                '测试你的 API 工具调用等能力是否正常）'
-        )
-        .default(true),
-    image: Schema.boolean()
+            '是否启用实验性“工具调用回复”功能（需同时开启“工具调用”，让模型通过工具调用完成状态更新、回复消息等原本依赖 XML 块的操作，在使用前请先查看文档）'
+        ),
+    toolCallReplyThinkTag: Schema.boolean()
+        .default(true)
         .description(
-            '是否允许输入图片（注意表情包也会输入，目前仅支持原生多模态的模型）'
-        )
-        .default(false),
-    imageInputMaxCount: Schema.number()
-        .default(9)
-        .min(1)
-        .max(15)
-        .description('最大的输入图片数量'),
-    imageInputMaxSize: Schema.number()
-        .default(20)
-        .min(1)
-        .max(100)
-        .description('最大的输入图片大小（MB）'),
-    multimodalFileInputMaxSize: Schema.number()
-        .default(20)
-        .min(1)
-        .max(100)
+            '是否启用 `<think>` 标签（使模型进行角色扮演式“思考”，展示角色的心路历程，主要起到观赏性作用）'
+        ),
+    toolCallReplyStatusTag: Schema.boolean()
+        .default(true)
         .description(
-            '最大的多模态文件输入大小（MB）：过大可能造成服务器卡顿、回复延迟'
+            '是否启用 `<status>` 标签（使模型可以临时性记忆更多上下文、维护自身状态信息，可以有效提升角色扮演效果）'
+        ),
+    toolCallReplyNextReply: Schema.boolean()
+        .default(true)
+        .description(
+            '是否启用 `next_reply`（使模型可以设置下一次短期主动触发条件）'
+        ),
+    toolCallReplyWakeUpReply: Schema.boolean()
+        .default(true)
+        .description(
+            '是否启用 `wake_up_reply`（使模型可以设置未来某个时间点的主动触发条件）'
         )
 })
-    .description('工具与多模态')
+    .description('工具调用回复')
     .collapse()
+
+const commonModelFeatureConfig = Schema.intersect([
+    Schema.object({
+        toolCalling: Schema.boolean()
+            .description(
+                '是否启用工具调用功能（可在[**这里**]' +
+                '(https://cooksleep.github.io/newapi-special-test)' +
+                '测试你的 API 工具调用等能力是否正常）'
+            )
+            .default(true),
+        image: Schema.boolean()
+            .description(
+                '是否允许输入图片（注意表情包也会输入，目前仅支持原生多模态的模型）'
+            )
+            .default(false),
+        imageInputMaxCount: Schema.number()
+            .default(9)
+            .min(1)
+            .max(15)
+            .description('最大的输入图片数量'),
+        imageInputMaxSize: Schema.number()
+            .default(20)
+            .min(1)
+            .max(100)
+            .description('最大的输入图片大小（MB）'),
+        multimodalFileInputMaxSize: Schema.number()
+            .default(20)
+            .min(1)
+            .max(100)
+            .description(
+                '最大的多模态文件输入大小（MB）：过大可能造成服务器卡顿、回复延迟'
+            )
+    })
+        .description('工具与多模态')
+        .collapse(),
+    commonToolCallReplyConfig
+])
 
 const privateIdleConfig = Schema.object({
     enableLongWaitTrigger: Schema.boolean()
@@ -551,12 +588,7 @@ export const Config = Schema.intersect([
         ).description('启用此插件时，不禁用 ChatLuna 主功能的私聊用户 ID 列表'),
         whiteListDisableChatLuna: Schema.array(Schema.string()).description(
             '启用此插件时，不禁用 ChatLuna 主功能的群聊 ID 列表'
-        ),
-        experimentalToolCallReply: Schema.boolean()
-            .default(false)
-            .description(
-                '是否启用实验性“工具调用回复”功能（需同时开启“工具调用”，让模型通过工具调用完成状态更新、回复消息等原本依赖 XML 块的操作）'
-            )
+        )
     })
         .description('基础配置')
         .collapse(),
@@ -604,6 +636,7 @@ type LegacyConfig = Config & {
     imageInputMaxSize?: number
     multimodalFileInputMaxSize?: number
     toolCalling?: boolean
+    experimentalToolCallReply?: boolean
     isForceMute?: boolean
     coolDownTime?: number
     muteTime?: number
@@ -628,22 +661,23 @@ type LegacyConfig = Config & {
 
 type CommonMigration = {
     key:
-        | 'maxMessages'
-        | 'maxTokens'
-        | 'image'
-        | 'imageInputMaxCount'
-        | 'imageInputMaxSize'
-        | 'multimodalFileInputMaxSize'
-        | 'toolCalling'
-        | 'isForceMute'
-        | 'coolDownTime'
-        | 'splitVoice'
-        | 'isNickname'
-        | 'isNickNameWithContent'
-        | 'statusPersistence'
-        | 'historyPull'
-        | 'modelCompletionCount'
-        | 'enableMessageId'
+    | 'maxMessages'
+    | 'maxTokens'
+    | 'image'
+    | 'imageInputMaxCount'
+    | 'imageInputMaxSize'
+    | 'multimodalFileInputMaxSize'
+    | 'toolCalling'
+    | 'experimentalToolCallReply'
+    | 'isForceMute'
+    | 'coolDownTime'
+    | 'splitVoice'
+    | 'isNickname'
+    | 'isNickNameWithContent'
+    | 'statusPersistence'
+    | 'historyPull'
+    | 'modelCompletionCount'
+    | 'enableMessageId'
     privateDefault: number | boolean
     groupDefault: number | boolean
     onlyFalse?: boolean
@@ -651,12 +685,12 @@ type CommonMigration = {
 
 type IdleMigration = {
     key:
-        | 'enableLongWaitTrigger'
-        | 'idleTriggerIntervalMinutes'
-        | 'idleTriggerRetryStyle'
-        | 'idleTriggerMaxIntervalMinutes'
-        | 'idleTriggerFixedMaxRetries'
-        | 'enableIdleTriggerJitter'
+    | 'enableLongWaitTrigger'
+    | 'idleTriggerIntervalMinutes'
+    | 'idleTriggerRetryStyle'
+    | 'idleTriggerMaxIntervalMinutes'
+    | 'idleTriggerFixedMaxRetries'
+    | 'enableIdleTriggerJitter'
     privateDefault: number | boolean | 'exponential' | 'fixed'
     groupDefault: number | boolean | 'exponential' | 'fixed'
     onlyFalse?: boolean
@@ -664,9 +698,9 @@ type IdleMigration = {
 
 type GroupMigration = {
     key:
-        | 'messageActivityScoreLowerLimit'
-        | 'messageActivityScoreUpperLimit'
-        | 'isAt'
+    | 'messageActivityScoreLowerLimit'
+    | 'messageActivityScoreUpperLimit'
+    | 'isAt'
     defaultValue: number | boolean
 }
 
@@ -689,6 +723,11 @@ const commonMigrations: CommonMigration[] = [
         privateDefault: true,
         groupDefault: true,
         onlyFalse: true
+    },
+    {
+        key: 'experimentalToolCallReply',
+        privateDefault: false,
+        groupDefault: false
     },
     {
         key: 'isForceMute',
@@ -764,6 +803,7 @@ const legacyKeys = [
     'imageInputMaxSize',
     'multimodalFileInputMaxSize',
     'toolCalling',
+    'experimentalToolCallReply',
     'isForceMute',
     'coolDownTime',
     'muteTime',
@@ -804,7 +844,6 @@ export function migrateConfig(config: Config): boolean {
         IdleMigration['key'],
         IdleValue
     >
-
     if (
         config.globalPrivateConfig.preset === 'CHARACTER' &&
         config.defaultPreset

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { MessageCollector } from './service/message'
 import { TriggerStore } from './service/trigger'
 import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
-import type {} from '@koishijs/plugin-console'
+import type { } from '@koishijs/plugin-console'
 
 export function apply(ctx: Context, config: Config) {
     const changed = migrateConfig(config)
@@ -126,6 +126,12 @@ export const usage = `
 ## chatluna-character
 
 请先阅读[**此文档**](https://chatluna.chat/ecosystem/other/character.html)了解使用方式。
+
+### 26.04.11
+
+“工具调用回复”功能的配置项已从“基础配置”下放至全局私聊／全局群聊／分私聊／分群聊配置中，并且支持分别调整 \`status\`、\`think\`、\`next_reply\`、\`wake_up_reply\` 字段是否启用。
+
+使用“工具调用回复”功能时，请尽可能使用模型官方（推荐的）API 格式（如：Gemini 使用 Gemini 适配器，Claude 及其他支持 Anthropic API 的模型使用 Claude 适配器），否则可能遇到无法正常完成回复的问题（尤其是 Minimax 等模型）。
 
 ### 26.04.05
 

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -735,7 +735,12 @@ function parseReplyTools(config: Config | GuildConfig | PrivateConfig, calls: Re
             }
         }
 
-        if (config.toolCallReplyNextReply && call.args.is_final !== false) {
+        if (
+            config.toolCallReplyNextReply &&
+            (!config.enableFixedIntervalTrigger ||
+                config.messageInterval !== 0) &&
+            call.args.is_final !== false
+        ) {
             nextReplyReasons.push(
                 ...extractNextReplyReasonsFromTool(call.args.next_reply)
             )

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -291,6 +291,10 @@ function buildNextReplyToolTags(value: unknown) {
     return tags
 }
 
+function renderToolText(value: string) {
+    return value.replaceAll('\\n', '\n')
+}
+
 function createReplyTools(
     ctx: Context,
     session: Session,
@@ -427,14 +431,6 @@ function createReplyTools(
             description:
                 'Whether this is the final reply of the current turn. Use false only for temporary progress updates when you still need more tools or more reasoning. Use true for the final reply of this turn.'
         },
-        status: {
-            type: 'string',
-            description: 'Updated status text.'
-        },
-        think: {
-            type: 'string',
-            description: 'The character\'s internal thoughts about the message.'
-        },
         messages: {
             type: 'array',
             description: 'List of messages to send. Each object in the array is one message. Use an empty array when no reply is needed.',
@@ -442,7 +438,10 @@ function createReplyTools(
                 ...message
             }
         },
-        wake_up_reply: {
+    }
+
+    if (config.toolCallReplyWakeUpReply) {
+        props['wake_up_reply'] = {
             type: 'array',
             description:
                 'Schedule future proactive triggers. Use this when you want to speak again at a specific later time, such as for a planned reminder or joke.',
@@ -465,7 +464,10 @@ function createReplyTools(
         }
     }
 
-    if (!config.enableFixedIntervalTrigger || config.messageInterval !== 0) {
+    if (
+        config.toolCallReplyNextReply &&
+        (!config.enableFixedIntervalTrigger || config.messageInterval !== 0)
+    ) {
         props['next_reply'] = {
             type: 'array',
             description:
@@ -513,6 +515,24 @@ function createReplyTools(
             }
         }
     }
+    const required = ['is_final', 'messages']
+
+    if (config.toolCallReplyStatusTag) {
+        props.status = {
+            type: 'string',
+            description:
+                'Updated status text. Do not include XML tags in this field.'
+        }
+        required.push('status')
+    }
+
+    if (config.toolCallReplyThinkTag) {
+        props.think = {
+            type: 'string',
+            description: 'The character\'s internal thoughts about the message.'
+        }
+        required.push('think')
+    }
 
     for (const field of ctx.chatluna_character.getReplyToolFields()) {
         if (field.isAvailable && !field.isAvailable(ctx, session, config)) {
@@ -547,12 +567,12 @@ function createReplyTools(
         }, {
             name: 'character_reply',
             description:
-                'Send one or more in-character reply messages and required actions. All user-visible reply content must be sent through this tool. Use real newlines in all string fields, not the literal string `\\n`. Do not manually wrap content in XML tags inside any field. Fill the structured fields directly. Do not end the turn with plain text output outside this tool.',
+                'Send one or more in-character reply messages and required actions. All user-visible reply content must be sent through this tool. Use the literal string `\\n` for line breaks in all string fields. Do not use real newline characters. Do not manually wrap content in XML tags inside any field. Fill the structured fields directly. Do not end the turn with plain text output outside this tool.',
             returnDirect: false,
             schema: {
                 type: 'object',
                 properties: props,
-                required: ['is_final', 'status', 'think', 'messages']
+                required
             }
         })
     ]
@@ -568,7 +588,10 @@ function formatReplyUserPrompt(session: Session, config: Config) {
         'All user-visible reply content must be sent through `character_reply`. Do not end the turn with plain text output outside this tool.'
     ]
 
-    if (!config.enableFixedIntervalTrigger || config.messageInterval !== 0) {
+    if (
+        config.toolCallReplyNextReply &&
+        (!config.enableFixedIntervalTrigger || config.messageInterval !== 0)
+    ) {
         tips.push('You should also actively decide whether this turn needs `next_reply`.')
     }
 
@@ -590,7 +613,7 @@ function buildXmlMessage(args: Record<string, unknown>) {
             .replaceAll('>', '&gt;')
 
         if (!attr) {
-            return text
+            return renderToolText(text)
         }
 
         return text.replaceAll('"', '&quot;')
@@ -689,7 +712,7 @@ function buildXmlMessage(args: Record<string, unknown>) {
     return `<message${quote}>${escape(args.text)}</message>`
 }
 
-function parseReplyTools(calls: ReplyToolCall[]) {
+function parseReplyTools(config: Config | GuildConfig | PrivateConfig, calls: ReplyToolCall[]) {
     const messages: string[] = []
     const nextReplyReasons: string[] = []
     const wakeUpReplies: { time: string; reason: string }[] = []
@@ -700,7 +723,7 @@ function parseReplyTools(calls: ReplyToolCall[]) {
             continue
         }
 
-        if (typeof call.args.status === 'string') {
+        if (config.toolCallReplyStatusTag && typeof call.args.status === 'string') {
             status = call.args.status
         }
 
@@ -712,13 +735,17 @@ function parseReplyTools(calls: ReplyToolCall[]) {
             }
         }
 
-        if (call.args.is_final !== false) {
+        if (config.toolCallReplyNextReply && call.args.is_final !== false) {
             nextReplyReasons.push(
                 ...extractNextReplyReasonsFromTool(call.args.next_reply)
             )
         }
 
-        if (call.args.is_final === false || !Array.isArray(call.args.wake_up_reply)) {
+        if (
+            !config.toolCallReplyWakeUpReply ||
+            call.args.is_final === false ||
+            !Array.isArray(call.args.wake_up_reply)
+        ) {
             continue
         }
 
@@ -767,11 +794,17 @@ function renderReplyToolXml(
         }
 
         if (typeof call.args.status === 'string') {
-            blocks.push(`<status>\n${call.args.status}\n</status>`)
+            if (config.toolCallReplyStatusTag) {
+                blocks.push(`<status>\n${renderToolText(call.args.status)}\n</status>`)
+            }
         }
 
-        if (typeof call.args.think === 'string' && call.args.think.trim()) {
-            blocks.push(`<think>\n${call.args.think.trim()}\n</think>`)
+        if (
+            config.toolCallReplyThinkTag &&
+            typeof call.args.think === 'string' &&
+            call.args.think.trim()
+        ) {
+            blocks.push(`<think>\n${renderToolText(call.args.think.trim())}\n</think>`)
         }
 
         if (Array.isArray(call.args.messages)) {
@@ -782,9 +815,11 @@ function renderReplyToolXml(
             }
         }
 
-        actions.push(...buildNextReplyToolTags(call.args.next_reply))
+        if (config.toolCallReplyNextReply) {
+            actions.push(...buildNextReplyToolTags(call.args.next_reply))
+        }
 
-        if (Array.isArray(call.args.wake_up_reply)) {
+        if (config.toolCallReplyWakeUpReply && Array.isArray(call.args.wake_up_reply)) {
             for (const item of call.args.wake_up_reply) {
                 if (!item || typeof item !== 'object' || Array.isArray(item)) {
                     continue
@@ -873,7 +908,7 @@ async function parseResponseContent(
     const { responseMessage, responseContent, isIntermediate } = chunk
     const toolState =
         config.experimentalToolCallReply && chunk.toolCalls?.length > 0
-            ? parseReplyTools(chunk.toolCalls)
+            ? parseReplyTools(config, chunk.toolCalls)
             : undefined
     const renderedContent =
         config.experimentalToolCallReply && chunk.toolCalls?.length > 0
@@ -1333,8 +1368,28 @@ async function prepareMessages(
     const userPrompt = formatReplyUserPrompt(session, config)
     const humanMessage = new HumanMessage(
         (await currentPreset.input.format(
+                {
+                    history_new: historyNewMessages
+                        .join('\n\n')
+                        .replaceAll('{', '{{')
+                        .replaceAll('}', '}}'),
+                    history_last: historyLast,
+                    time: formatTimestamp(new Date()),
+                    stickers: '',
+                    status: temp.status ?? currentPreset.status ?? '',
+                    trigger_reason: triggerReasonText,
+                    prompt: session.content,
+                    built
+                },
+                session.app.chatluna.promptRenderer,
+                {
+                    session
+                }
+            )) + (userPrompt.length > 0 ? `\n\n${userPrompt}` : '')
+    )
+    const prompt = await currentPreset.input.format(
             {
-                history_new: historyNewMessages
+                history_new: recentMessages
                     .join('\n\n')
                     .replaceAll('{', '{{')
                     .replaceAll('}', '}}'),
@@ -1350,26 +1405,6 @@ async function prepareMessages(
             {
                 session
             }
-        )) + (userPrompt.length > 0 ? `\n\n${userPrompt}` : '')
-    )
-    const prompt = await currentPreset.input.format(
-        {
-            history_new: recentMessages
-                .join('\n\n')
-                .replaceAll('{', '{{')
-                .replaceAll('}', '}}'),
-            history_last: historyLast,
-            time: formatTimestamp(new Date()),
-            stickers: '',
-            status: temp.status ?? currentPreset.status ?? '',
-            trigger_reason: triggerReasonText,
-            prompt: session.content,
-            built
-        },
-        session.app.chatluna.promptRenderer,
-        {
-            session
-        }
     )
     const persistedHumanMessage = new HumanMessage(
         prompt + (userPrompt.length > 0 ? `\n\n${userPrompt}` : '')
@@ -1741,33 +1776,43 @@ export async function apply(ctx: Context, config: Config) {
     const preset = service.preset
     logger = service.logger
 
-    if (config.experimentalToolCallReply) {
+    if (config.globalPrivateConfig.experimentalToolCallReply) {
         if (!config.globalPrivateConfig.toolCalling) {
             throw new Error(
-                'experimentalToolCallReply 依赖 toolCalling，globalPrivateConfig.toolCalling 不能关闭。'
+                'globalPrivateConfig.experimentalToolCallReply 依赖 toolCalling，globalPrivateConfig.toolCalling 不能关闭。'
             )
         }
+    }
 
+    if (config.globalGroupConfig.experimentalToolCallReply) {
         if (!config.globalGroupConfig.toolCalling) {
             throw new Error(
-                'experimentalToolCallReply 依赖 toolCalling，globalGroupConfig.toolCalling 不能关闭。'
+                'globalGroupConfig.experimentalToolCallReply 依赖 toolCalling，globalGroupConfig.toolCalling 不能关闭。'
             )
         }
+    }
 
-        for (const [id, cfg] of Object.entries(config.privateConfigs)) {
-            if (!cfg.toolCalling) {
-                throw new Error(
-                    `experimentalToolCallReply 依赖 toolCalling，privateConfigs.${id}.toolCalling 不能关闭。`
-                )
-            }
+    for (const [id, cfg] of Object.entries(config.privateConfigs)) {
+        if (!cfg.experimentalToolCallReply) {
+            continue
         }
 
-        for (const [id, cfg] of Object.entries(config.configs)) {
-            if (!cfg.toolCalling) {
-                throw new Error(
-                    `experimentalToolCallReply 依赖 toolCalling，configs.${id}.toolCalling 不能关闭。`
-                )
-            }
+        if (!cfg.toolCalling) {
+            throw new Error(
+                `privateConfigs.${id}.experimentalToolCallReply 依赖 toolCalling，privateConfigs.${id}.toolCalling 不能关闭。`
+            )
+        }
+    }
+
+    for (const [id, cfg] of Object.entries(config.configs)) {
+        if (!cfg.experimentalToolCallReply) {
+            continue
+        }
+
+        if (!cfg.toolCalling) {
+            throw new Error(
+                `configs.${id}.experimentalToolCallReply 依赖 toolCalling，configs.${id}.toolCalling 不能关闭。`
+            )
         }
     }
 
@@ -1967,7 +2012,7 @@ export async function apply(ctx: Context, config: Config) {
                     }
 
                     if (copyOfConfig.experimentalToolCallReply && chunk.toolCalls) {
-                        const toolState = parseReplyTools(chunk.toolCalls)
+                        const toolState = parseReplyTools(copyOfConfig, chunk.toolCalls)
                         nextReplyReasons.push(...toolState.nextReplyReasons)
                         wakeUpReplies.push(...toolState.wakeUpReplies)
                     } else {

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -820,7 +820,12 @@ function renderReplyToolXml(
             }
         }
 
-        if (config.toolCallReplyNextReply) {
+        if (
+            config.toolCallReplyNextReply &&
+            (!config.enableFixedIntervalTrigger ||
+                config.messageInterval !== 0) &&
+            call.args.is_final !== false
+        ) {
             actions.push(...buildNextReplyToolTags(call.args.next_reply))
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,11 @@ export interface GuildConfig {
     muteTime: number
     modelCompletionCount: number
     toolCalling: boolean
+    experimentalToolCallReply: boolean
+    toolCallReplyThinkTag: boolean
+    toolCallReplyStatusTag: boolean
+    toolCallReplyNextReply: boolean
+    toolCallReplyWakeUpReply: boolean
     historyPull: boolean
     statusPersistence: boolean
 }


### PR DESCRIPTION
## 总结

- 将 experimentalToolCallReply 从基础配置下放到全局私聊、全局群聊、分私聊、分群聊配置中。
- 为工具调用回复新增 think、status、next_reply、wake_up_reply 的独立开关，并让禁用后的字段从工具参数、渲染与处理流程中一并消失。
- 更新插件内使用说明，补充新的配置位置与字段行为。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Granular control for tool-call replies: independently enable/disable status tags, think tags, next-reply suggestions, and wake-up replies.
  * Tool-call reply settings moved from basic/global to scope-specific (global/private/group/per-scope).

* **Behavior Changes**
  * Tool reply text now respects literal "\n" for line breaks and emits status/think/next/wake actions only when enabled.

* **Documentation**
  * Usage docs updated to cover configuration migration and new options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->