### PR TITLE
chore(package): bump version to 0.0.211

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-character",
     "description": "Let the large language model play a role, disguise as a group friend",
-    "version": "0.0.210",
+    "version": "0.0.211",
     "type": "module",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",


### PR DESCRIPTION
## Summary
- 将 `koishi-plugin-chatluna-character` 版本更新到 `0.0.211`，用于触发 Publish workflow 发布包含 PR #74 的 npm 新版本。

## Tests
- 未运行，本次仅更新 `package.json` 版本号。
