### PR TITLE
fix(config): normalize reply tool override

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -1281,7 +1281,11 @@ async function getConfigAndPresetForGuild(
         copyOfConfig = Object.assign(
             {},
             copyOfConfig,
-            currentGuildConfig
+            currentGuildConfig,
+            {
+                experimentalToolCallReply:
+                    currentGuildConfig.experimentalToolCallReply === true
+            }
         ) as RuntimeConfig
         currentPreset =
             presetPool[key] ??


### PR DESCRIPTION
## Summary
- 对分私聊/分群配置覆盖后的 `experimentalToolCallReply` 再次执行显式布尔化。
- 避免未完整初始化的分配置把 `RuntimeConfig.experimentalToolCallReply` 覆盖成 `undefined`。
- 跟进 PR #74 的 Gemini Code Assist 审评意见。

## Tests
- `yarn tsc --noEmit`
- `yarn fast-build`
