### PR TITLE
fix(config): simplify runtime config merge

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -1271,10 +1271,7 @@ async function getConfigAndPresetForGuild(
     const currentGuildConfig = isDirect
         ? config.privateConfigs[guildId]
         : config.configs[guildId]
-    let copyOfConfig = Object.assign({}, config, globalConfig, {
-        experimentalToolCallReply:
-            globalConfig.experimentalToolCallReply === true
-    }) as RuntimeConfig
+    let copyOfConfig = Object.assign({}, config, globalConfig) as RuntimeConfig
     let currentPreset = isDirect ? globalPrivatePreset : globalGroupPreset
 
     if (currentGuildConfig) {


### PR DESCRIPTION
## Summary
- 移除 `experimentalToolCallReply` 的字段级特殊归一化，恢复普通的全局/分配置合并流程。
- 保留 `RuntimeConfig` 仅用于表达聊天运行时的合并配置类型，避免重新引入旧顶层字段。
- 替代并关闭 PR #76，避免为单个配置项引入过度特殊处理。

## Tests
- `yarn tsc --noEmit`
- `yarn fast-build`
