### PR TITLE
chore(package): bump version to 0.0.213

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-character",
     "description": "Let the large language model play a role, disguise as a group friend",
-    "version": "0.0.212",
+    "version": "0.0.213",
     "type": "module",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",


### PR DESCRIPTION
## Summary

- 将 `koishi-plugin-chatluna-character` 版本号提升到 `0.0.213`，用于发布已合并的 `wake_up_reply` 计划任务工具改动。

## Test

- 未运行，版本号变更仅影响发版元数据。
