### PR TITLE
fix: validate character reply tool input

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -333,6 +333,25 @@ function getReplyToolInputError(
     return undefined
 }
 
+function filterReplyToolCalls(
+    config: Config | GuildConfig | PrivateConfig,
+    calls: ReplyToolCall[]
+) {
+    return calls.filter((call) => {
+        if (call.name !== 'character_reply') {
+            return true
+        }
+
+        const err = getReplyToolInputError(config, call.args)
+        if (err) {
+            logger.debug(`Skip invalid character_reply tool call: ${err}`)
+            return false
+        }
+
+        return true
+    })
+}
+
 function createReplyTools(
     ctx: Context,
     session: Session,
@@ -995,12 +1014,6 @@ function parseReplyTools(
             continue
         }
 
-        const err = getReplyToolInputError(config, call.args)
-        if (err) {
-            logger.debug(`Skip invalid character_reply tool call: ${err}`)
-            continue
-        }
-
         if (
             config.toolCallReplyStatusTag &&
             typeof call.args.status === 'string'
@@ -1050,12 +1063,6 @@ function renderReplyToolXml(
 
     for (const call of calls) {
         if (call.name !== 'character_reply') {
-            continue
-        }
-
-        const err = getReplyToolInputError(config, call.args)
-        if (err) {
-            logger.debug(`Skip invalid character_reply tool call: ${err}`)
             continue
         }
 
@@ -1153,14 +1160,16 @@ async function parseResponseContent(
 ): Promise<StreamedParsedResponseChunk> {
     let parsedResponse: ParsedResponse
     const { responseMessage, responseContent, isIntermediate } = chunk
-    const toolState =
+    const calls =
         config.experimentalToolCallReply && chunk.toolCalls?.length > 0
-            ? parseReplyTools(config, chunk.toolCalls)
+            ? filterReplyToolCalls(config, chunk.toolCalls)
             : undefined
-    const renderedContent =
-        config.experimentalToolCallReply && chunk.toolCalls?.length > 0
-            ? renderReplyToolXml(ctx, session, config, chunk.toolCalls)
-            : responseContent
+    const toolState =
+        calls && calls.length > 0 ? parseReplyTools(config, calls) : undefined
+    const hasCalls = calls && calls.length > 0
+    const renderedContent = hasCalls
+        ? renderReplyToolXml(ctx, session, config, calls)
+        : responseContent
 
     if (
         !toolState &&
@@ -1236,7 +1245,7 @@ async function parseResponseContent(
     return {
         responseMessage,
         responseContent: renderedContent,
-        toolCalls: chunk.toolCalls,
+        toolCalls: calls,
         parsedResponse
     }
 }
@@ -1304,8 +1313,14 @@ async function* streamAgentResponseContents(
     )
 
     for await (const responseChunk of responseStream) {
+        const calls =
+            config.experimentalToolCallReply &&
+            responseChunk.toolCalls?.length > 0
+                ? filterReplyToolCalls(config, responseChunk.toolCalls)
+                : responseChunk.toolCalls
+
         if (
-            responseChunk.toolCalls?.some((call) => {
+            calls?.some((call) => {
                 return (
                     call.name === 'character_reply' &&
                     call.args.is_final !== false
@@ -1318,7 +1333,7 @@ async function* streamAgentResponseContents(
         if (
             finalReply &&
             responseChunk.phase === 'final' &&
-            (!responseChunk.toolCalls || responseChunk.toolCalls.length < 1)
+            (!calls || calls.length < 1)
         ) {
             continue
         }
@@ -1337,13 +1352,12 @@ async function* streamAgentResponseContents(
         }
 
         const renderedContent =
-            config.experimentalToolCallReply &&
-            responseChunk.toolCalls?.length > 0
+            config.experimentalToolCallReply && calls && calls.length > 0
                 ? renderReplyToolXml(
                       ctx,
                       session,
                       config,
-                      responseChunk.toolCalls
+                      calls
                   )
                 : responseContent
         if (renderedContent.trim().length < 1) {
@@ -1360,7 +1374,7 @@ async function* streamAgentResponseContents(
             responseMessage,
             responseContent: renderedContent,
             isIntermediate,
-            toolCalls: responseChunk.toolCalls
+            toolCalls: calls
         }
     }
 }

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -296,62 +296,6 @@ function renderToolText(value: string) {
     return value.replaceAll('\\n', '\n')
 }
 
-function getReplyToolInputError(
-    config: Config | GuildConfig | PrivateConfig,
-    args: Record<string, unknown>
-) {
-    const missing = ['is_final', 'messages'].filter((key) => args[key] == null)
-
-    if (config.toolCallReplyStatusTag && args.status == null) {
-        missing.push('status')
-    }
-
-    if (config.toolCallReplyThinkTag && args.think == null) {
-        missing.push('think')
-    }
-
-    if (missing.length > 0) {
-        return `Missing required field(s): ${missing.join(', ')}`
-    }
-
-    if (typeof args.is_final !== 'boolean') {
-        return 'Field is_final must be a boolean'
-    }
-
-    if (!Array.isArray(args.messages)) {
-        return 'Field messages must be an array'
-    }
-
-    if (config.toolCallReplyStatusTag && typeof args.status !== 'string') {
-        return 'Field status must be a string'
-    }
-
-    if (config.toolCallReplyThinkTag && typeof args.think !== 'string') {
-        return 'Field think must be a string'
-    }
-
-    return undefined
-}
-
-function filterReplyToolCalls(
-    config: Config | GuildConfig | PrivateConfig,
-    calls: ReplyToolCall[]
-) {
-    return calls.filter((call) => {
-        if (call.name !== 'character_reply') {
-            return true
-        }
-
-        const err = getReplyToolInputError(config, call.args)
-        if (err) {
-            logger.debug(`Skip invalid character_reply tool call: ${err}`)
-            return false
-        }
-
-        return true
-    })
-}
-
 function createReplyTools(
     ctx: Context,
     session: Session,
@@ -1353,12 +1297,7 @@ async function* streamAgentResponseContents(
 
         const renderedContent =
             config.experimentalToolCallReply && calls && calls.length > 0
-                ? renderReplyToolXml(
-                      ctx,
-                      session,
-                      config,
-                      calls
-                  )
+                ? renderReplyToolXml(ctx, session, config, calls)
                 : responseContent
         if (renderedContent.trim().length < 1) {
             continue
@@ -2364,5 +2303,61 @@ export async function apply(ctx: Context, config: Config) {
                 )
             }
         }
+    })
+}
+
+function getReplyToolInputError(
+    config: Config | GuildConfig | PrivateConfig,
+    args: Record<string, unknown>
+) {
+    const missing = ['is_final', 'messages'].filter((key) => args[key] == null)
+
+    if (config.toolCallReplyStatusTag && args.status == null) {
+        missing.push('status')
+    }
+
+    if (config.toolCallReplyThinkTag && args.think == null) {
+        missing.push('think')
+    }
+
+    if (missing.length > 0) {
+        return `Missing required field(s): ${missing.join(', ')}`
+    }
+
+    if (typeof args.is_final !== 'boolean') {
+        return 'Field is_final must be a boolean'
+    }
+
+    if (!Array.isArray(args.messages)) {
+        return 'Field messages must be an array'
+    }
+
+    if (config.toolCallReplyStatusTag && typeof args.status !== 'string') {
+        return 'Field status must be a string'
+    }
+
+    if (config.toolCallReplyThinkTag && typeof args.think !== 'string') {
+        return 'Field think must be a string'
+    }
+
+    return undefined
+}
+
+function filterReplyToolCalls(
+    config: Config | GuildConfig | PrivateConfig,
+    calls: ReplyToolCall[]
+) {
+    return calls.filter((call) => {
+        if (call.name !== 'character_reply') {
+            return true
+        }
+
+        const err = getReplyToolInputError(config, call.args)
+        if (err) {
+            logger.debug(`Skip invalid character_reply tool call: ${err}`)
+            return false
+        }
+
+        return true
     })
 }

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -1129,7 +1129,7 @@ async function parseResponseContent(
         return {
             responseMessage,
             responseContent: renderedContent,
-            toolCalls: chunk.toolCalls,
+            toolCalls: calls,
             parsedResponse: {
                 elements: [],
                 rawMessage: responseContent,

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -296,6 +296,43 @@ function renderToolText(value: string) {
     return value.replaceAll('\\n', '\n')
 }
 
+function getReplyToolInputError(
+    config: Config | GuildConfig | PrivateConfig,
+    args: Record<string, unknown>
+) {
+    const missing = ['is_final', 'messages'].filter((key) => args[key] == null)
+
+    if (config.toolCallReplyStatusTag && args.status == null) {
+        missing.push('status')
+    }
+
+    if (config.toolCallReplyThinkTag && args.think == null) {
+        missing.push('think')
+    }
+
+    if (missing.length > 0) {
+        return `Missing required field(s): ${missing.join(', ')}`
+    }
+
+    if (typeof args.is_final !== 'boolean') {
+        return 'Field is_final must be a boolean'
+    }
+
+    if (!Array.isArray(args.messages)) {
+        return 'Field messages must be an array'
+    }
+
+    if (config.toolCallReplyStatusTag && typeof args.status !== 'string') {
+        return 'Field status must be a string'
+    }
+
+    if (config.toolCallReplyThinkTag && typeof args.think !== 'string') {
+        return 'Field think must be a string'
+    }
+
+    return undefined
+}
+
 function createReplyTools(
     ctx: Context,
     session: Session,
@@ -567,6 +604,7 @@ function createReplyTools(
                     description:
                         'Send one or more in-character reply messages and required actions. All user-visible reply content must be sent through this tool. Use the literal string `\\n` for line breaks in all string fields. Do not use real newline characters. Do not manually wrap content in XML tags inside any field. Fill the structured fields directly. Do not end the turn with plain text output outside this tool.',
                     returnDirect: false,
+                    verboseParsingErrors: true,
                     schema: {
                         type: 'object',
                         properties: props,
@@ -957,6 +995,12 @@ function parseReplyTools(
             continue
         }
 
+        const err = getReplyToolInputError(config, call.args)
+        if (err) {
+            logger.debug(`Skip invalid character_reply tool call: ${err}`)
+            continue
+        }
+
         if (
             config.toolCallReplyStatusTag &&
             typeof call.args.status === 'string'
@@ -1006,6 +1050,12 @@ function renderReplyToolXml(
 
     for (const call of calls) {
         if (call.name !== 'character_reply') {
+            continue
+        }
+
+        const err = getReplyToolInputError(config, call.args)
+        if (err) {
+            logger.debug(`Skip invalid character_reply tool call: ${err}`)
             continue
         }
 

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -202,20 +202,7 @@ export async function createChatLunaChain(
         prompt: chatPrompt.value,
         agentMode: 'tool-calling',
         returnIntermediateSteps: false,
-        handleParsingErrors: ((err: Error) => {
-            const missing = Array.from(
-                err.message.matchAll(
-                    /must have required property '([^']+)'/g
-                ),
-                (item) => item[1]
-            )
-
-            if (missing.length > 0) {
-                return `Invalid or incomplete tool input. Missing required field(s): ${missing.join(', ')}. Please call the tool again with all required fields.`
-            }
-
-            return `Invalid or incomplete tool input. ${err.message}. Please fix the schema mismatch and try again.`
-        }) as unknown as boolean,
+        handleParsingErrors: true,
         instructions: computed(() => undefined)
     })
 

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -202,7 +202,20 @@ export async function createChatLunaChain(
         prompt: chatPrompt.value,
         agentMode: 'tool-calling',
         returnIntermediateSteps: false,
-        handleParsingErrors: true,
+        handleParsingErrors: ((err: Error) => {
+            const missing = Array.from(
+                err.message.matchAll(
+                    /must have required property '([^']+)'/g
+                ),
+                (item) => item[1]
+            )
+
+            if (missing.length > 0) {
+                return `Invalid or incomplete tool input. Missing required field(s): ${missing.join(', ')}. Please call the tool again with all required fields.`
+            }
+
+            return `Invalid or incomplete tool input. ${err.message}. Please fix the schema mismatch and try again.`
+        }) as unknown as boolean,
         instructions: computed(() => undefined)
     })
 


### PR DESCRIPTION
## 概要

- 在提前渲染并发送 `character_reply` 前校验必填字段与基础类型，避免无效工具调用先发出消息。
- 为 `character_reply` 开启 verbose schema 错误，帮助模型看到具体缺失字段。
- 集中过滤无效 `character_reply` 工具调用，避免重复校验与重复发送。

## 验证

- `yarn tsc --noEmit`
- `yarn fast-build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation and filtering of character reply tool inputs to prevent invalid entries from being processed.
  * Invalid character replies are now properly skipped with debug logging.
  * Improved error handling for tool call parsing with more detailed error reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChatLunaLab/chatluna-character/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->