### PR TITLE
fix: 重试无效模型回复

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -1724,55 +1724,80 @@ async function* streamModelResponse(
 ): AsyncGenerator<StreamedParsedResponseChunk> {
     if (signal?.aborted) return
 
-    try {
-        const lastMessage = completionMessages[completionMessages.length - 1]
-        const historyMessages = completionMessages.slice(0, -1)
+    let err: unknown
+    for (let idx = 0; idx < 2; idx++) {
+        try {
+            const messages =
+                idx === 0 || !String(err).includes('Failed to parse response')
+                    ? completionMessages
+                    : completionMessages.concat(
+                          new HumanMessage(
+                              config.experimentalToolCallReply &&
+                                  config.toolCalling
+                                  ? 'Your previous reply was not sent through `character_reply`, so it could not be delivered. ' +
+                                        'Do not repeat completed external tool calls unless necessary. ' +
+                                        'Use the content from the previous reply and call `character_reply` now. Previous error:\n' +
+                                        String(err)
+                                  : 'Your previous reply used an invalid format and could not be delivered. ' +
+                                        'Reply again using valid XML output with <message> tags. Previous error:\n' +
+                                        String(err)
+                          )
+                      )
+            const lastMessage = messages[messages.length - 1]
+            const historyMessages = messages.slice(0, -1)
 
-        const systemMessage =
-            chain != null ? historyMessages.shift() : undefined
+            const systemMessage =
+                chain != null ? historyMessages.shift() : undefined
 
-        if (chain) {
-            for await (const responseChunk of streamAgentResponseContents(
-                ctx,
-                chain,
-                session,
-                model,
-                config,
-                presetName,
-                systemMessage,
-                historyMessages,
-                lastMessage,
-                signal,
-                messageQueue,
-                onAgentEvent
-            )) {
-                yield await parseResponseContent(
+            if (chain) {
+                for await (const responseChunk of streamAgentResponseContents(
                     ctx,
+                    chain,
                     session,
+                    model,
                     config,
-                    responseChunk
-                )
+                    presetName,
+                    systemMessage,
+                    historyMessages,
+                    lastMessage,
+                    signal,
+                    messageQueue,
+                    onAgentEvent
+                )) {
+                    yield await parseResponseContent(
+                        ctx,
+                        session,
+                        config,
+                        responseChunk
+                    )
+                }
+
+                return
             }
 
+            const responseMessage = await model.invoke(
+                messages,
+                createStreamConfig(session, model, presetName, signal)
+            )
+            const responseContent = getMessageContent(responseMessage.content)
+
+            logger.debug(`model response:\n${responseContent}`)
+
+            yield await parseResponseContent(ctx, session, config, {
+                responseMessage,
+                responseContent,
+                isIntermediate: false
+            })
             return
+        } catch (e) {
+            if (signal?.aborted) return
+            if (idx < 1) {
+                err = e
+                logger.warn('model response failed, retry once', e)
+                continue
+            }
+            logger.error('model requests failed', e)
         }
-
-        const responseMessage = await model.invoke(
-            completionMessages,
-            createStreamConfig(session, model, presetName, signal)
-        )
-        const responseContent = getMessageContent(responseMessage.content)
-
-        logger.debug(`model response:\n${responseContent}`)
-
-        yield await parseResponseContent(ctx, session, config, {
-            responseMessage,
-            responseContent,
-            isIntermediate: false
-        })
-    } catch (e) {
-        if (signal?.aborted) return
-        logger.error('model requests failed', e)
     }
 }
 

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -1725,22 +1725,22 @@ async function* streamModelResponse(
     if (signal?.aborted) return
 
     let err: unknown
+    let failedMessage: BaseMessage | undefined
     for (let idx = 0; idx < 2; idx++) {
         try {
             const messages =
                 idx === 0 || !String(err).includes('Failed to parse response')
                     ? completionMessages
                     : completionMessages.concat(
+                          ...(failedMessage ? [failedMessage] : []),
                           new HumanMessage(
                               config.experimentalToolCallReply &&
                                   config.toolCalling
                                   ? 'Your previous reply was not sent through `character_reply`, so it could not be delivered. ' +
                                         'Do not repeat completed external tool calls unless necessary. ' +
-                                        'Use the content from the previous reply and call `character_reply` now. Previous error:\n' +
-                                        String(err)
+                                        'Use the content from the previous reply and call `character_reply` now.'
                                   : 'Your previous reply used an invalid format and could not be delivered. ' +
-                                        'Reply again using valid XML output with <message> tags. Previous error:\n' +
-                                        String(err)
+                                        'Reply again using valid XML output with <message> tags.'
                           )
                       )
             const lastMessage = messages[messages.length - 1]
@@ -1764,6 +1764,7 @@ async function* streamModelResponse(
                     messageQueue,
                     onAgentEvent
                 )) {
+                    failedMessage = responseChunk.responseMessage
                     yield await parseResponseContent(
                         ctx,
                         session,
@@ -1779,6 +1780,7 @@ async function* streamModelResponse(
                 messages,
                 createStreamConfig(session, model, presetName, signal)
             )
+            failedMessage = responseMessage
             const responseContent = getMessageContent(responseMessage.content)
 
             logger.debug(`model response:\n${responseContent}`)


### PR DESCRIPTION
## 变更内容

- 为最终模型回复解析失败增加一次立即重试。
- 当失败原因为 `Failed to parse response` 时，在重试请求中追加格式纠错提示。
- `experimentalToolCallReply` 模式下要求模型复用上次答案内容并通过 `character_reply` 发送，避免长程工具任务结束后因纯文本回复导致消息丢失。

## 验证

- `yarn tsc --noEmit`
- `yarn fast-build`

Fixes #88


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat reliability with an automatic two-attempt retry for failed responses.
  * Better recovery when parsing fails: on a second attempt the system prompts the model to correct its output and logs the first failure as a warning and the second as an error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChatLunaLab/chatluna-character/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->