### PR TITLE
chore(package): bump version to 0.0.216

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-character",
     "description": "Let the large language model play a role, disguise as a group friend",
-    "version": "0.0.215",
+    "version": "0.0.216",
     "type": "module",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",


### PR DESCRIPTION
## 变更内容

- 将 `koishi-plugin-chatluna-character` 版本从 `0.0.215` 升至 `0.0.216`。
- 合并到上游 `main` 后触发 `Publish` workflow 发布 npm 新版本。

## 验证

- `npm view koishi-plugin-chatluna-character version`：`0.0.215`
- `yarn tsc --noEmit`
- `yarn fast-build`
