### PR TITLE
Preserve text in mixed character_reply messages

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -864,45 +864,49 @@ function buildXmlMessage(args: Record<string, unknown>) {
             ? ` quote="${escape(args.quote, true)}"`
             : ''
 
+    let content = ''
+
+    if (typeof args.at === 'string') {
+        content += `<at>${escape(args.at)}</at>`
+    }
+
+    if (typeof args.face === 'string' || typeof args.face === 'number') {
+        content += `<face>${escape(args.face)}</face>`
+    }
+
+    if (typeof args.text === 'string') {
+        content += escape(args.text)
+    }
+
     if (Array.isArray(args.parts)) {
-        const content = args.parts
+        content += args.parts
             .filter(
                 (item) =>
                     item && typeof item === 'object' && !Array.isArray(item)
             )
             .map((item) => buildPart(item as Record<string, unknown>))
             .join('')
-
-        return `<message${quote}>${content}</message>`
-    }
-
-    if (typeof args.at === 'string') {
-        return `<message${quote}><at>${escape(args.at)}</at></message>`
-    }
-
-    if (typeof args.face === 'string') {
-        return `<message${quote}><face>${escape(args.face)}</face></message>`
     }
 
     if (typeof args.sticker === 'string') {
         if (!isHttpUrl(args.sticker)) {
-            return `<message${quote}></message>`
+            return `<message${quote}>${content}</message>`
         }
-        return `<message${quote}><sticker>${escape(args.sticker)}</sticker></message>`
+        content += `<sticker>${escape(args.sticker)}</sticker>`
     }
 
     if (typeof args.image === 'string') {
         if (!isHttpUrl(args.image)) {
-            return `<message${quote}></message>`
+            return `<message${quote}>${content}</message>`
         }
-        return `<message${quote}><image>${escape(args.image)}</image></message>`
+        content += `<image>${escape(args.image)}</image>`
     }
 
     if (typeof args.audio === 'string') {
         if (!isHttpUrl(args.audio)) {
-            return `<message${quote}></message>`
+            return `<message${quote}>${content}</message>`
         }
-        return `<message${quote}><audio>${escape(args.audio)}</audio></message>`
+        content += `<audio>${escape(args.audio)}</audio>`
     }
 
     if (
@@ -912,9 +916,9 @@ function buildXmlMessage(args: Record<string, unknown>) {
     ) {
         const file = args.file as Record<string, unknown>
         if (!isHttpUrl(file.url)) {
-            return `<message${quote}></message>`
+            return `<message${quote}>${content}</message>`
         }
-        return `<message${quote}><file name="${escape(file.name ?? 'file', true)}">${escape(file.url)}</file></message>`
+        content += `<file name="${escape(file.name ?? 'file', true)}">${escape(file.url)}</file>`
     }
 
     if (
@@ -924,13 +928,13 @@ function buildXmlMessage(args: Record<string, unknown>) {
     ) {
         const video = args.video as Record<string, unknown>
         if (!isHttpUrl(video.url)) {
-            return `<message${quote}></message>`
+            return `<message${quote}>${content}</message>`
         }
-        return `<message${quote}><video>${escape(video.url)}</video></message>`
+        content += `<video>${escape(video.url)}</video>`
     }
 
     if (typeof args.markdown === 'string') {
-        return `<message${quote}><markdown>${escape(args.markdown)}</markdown></message>`
+        content += `<markdown>${escape(args.markdown)}</markdown>`
     }
 
     if (
@@ -939,10 +943,10 @@ function buildXmlMessage(args: Record<string, unknown>) {
         !Array.isArray(args.voice)
     ) {
         const voice = args.voice as Record<string, unknown>
-        return `<message${quote}><voice id="${escape(voice.id, true)}">${escape(voice.text)}</voice></message>`
+        content += `<voice id="${escape(voice.id, true)}">${escape(voice.text)}</voice>`
     }
 
-    return `<message${quote}>${escape(args.text)}</message>`
+    return `<message${quote}>${content}</message>`
 }
 
 function parseReplyTools(


### PR DESCRIPTION
## Summary

Fix `character_reply` structured message rendering so top-level mixed fields preserve user-visible text instead of being treated as mutually exclusive.

Before this change, `buildXmlMessage()` returned as soon as it saw fields such as `at`, `face`, `sticker`, `image`, `audio`, `file`, `video`, `markdown`, or `voice`. This silently dropped `text` when a model produced valid-looking structured tool input like:

```json
{ "text": "Browser test succeeded", "image": "https://example.com/screenshot.png" }
```

This PR changes `buildXmlMessage()` to compose top-level fields into one `<message>` and then append `parts`, instead of returning early. It also accepts numeric `face` values, which appeared in real model output.

## Production Evidence

Observed on `koishi-plugin-chatluna-character@0.0.216` in a Koishi production instance.

Before patch, real logs showed:

- `text + image` rendered as image-only
- `text + sticker` rendered as sticker-only
- `text + at` rendered as at-only
- `text + voice` rendered as voice-only
- `text + parts` rendered as parts-only
- numeric `face` became an empty message

Representative pre-patch log evidence:

```text
[3728] toolInput.messages:
[{ "image": "https://http.cat/200", "text": "测试7️⃣：image字段，发一张猫咪图~" }]

[3729] rendered output:
<message><image>https://http.cat/200</image></message>
```

```text
[3741] toolInput.messages:
[{ "text": "测试8️⃣：voice语音字段！sensei听听看~", "voice": { "text": "テストです。音声機能のテストに成功しました！", "id": "0" } }]

[3742] rendered output:
<message><voice id="0">テストです。音声機能のテストに成功しました！</voice></message>
```

After deploying this patch to the same production instance and rerunning the mixed-field tests:

```text
[620] toolInput.messages:
F-01 text + image
F-02 text + sticker
F-03 text + at
F-04 text + face

[621] rendered output:
<message>【F-01】顶层 text + image 测试 —— 这条同时设置了 text 和 image 字段<image>...</image></message>
<message>【F-02】顶层 text + sticker 测试 —— 这条同时设置了 text 和 sticker 字段<sticker>...</sticker></message>
<message><at>2657455842</at>【F-03】顶层 text + at 测试 —— 这条同时设置了 text 和 at 字段</message>
<message><face>178</face>【F-04】顶层 text + face 测试 —— 这条同时设置了 text 和 face 字段</message>
```

```text
[627] toolInput.messages:
F-05 text + voice
F-06 text + parts

[644] rendered output:
<message>【F-05】顶层 text + voice 测试 —— 这条同时设置了 text 和 voice 字段<voice id="0">...</voice></message>
<message>【F-06】顶层 text + parts 测试 —— 这条同时设置了 text 和 parts 字段parts前段<image>...</image>parts后段</message>
```

## Validation

- `yarn fast-build` passes locally.
- A patched build was deployed to the production Koishi instance.
- `systemctl is-active koishi` returned `active` after deployment.
- Post-patch logs confirm top-level `text` is preserved for `image`, `sticker`, `at`, `face`, `voice`, and `parts` combinations.

## Notes

The XML parser already supports mixed message content. The bug was in the structured `character_reply` args to XML conversion layer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved message composition to allow multiple content types (text, media, emojis) to coexist in a single message.
  * Enhanced flexibility in emoji/face input handling.

* **Bug Fixes**
  * Fixed message content preservation when media URLs are invalid—partial messages now retain accumulated content instead of being discarded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChatLunaLab/chatluna-character/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->