### PR TITLE
feat: 增加 Character 生命周期事件

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,11 @@ export const usage = `
 export { Config } from './config'
 export type {
     CharacterAfterChatEventPayload,
+    CharacterBaseMessageSnapshot,
     CharacterBeforeChatEventPayload,
-    CharacterClearChatHistoryEventPayload
+    CharacterClearChatHistoryEventPayload,
+    CharacterMessageSnapshot,
+    CharacterPresetSnapshot,
+    CharacterPromptTemplateSnapshot
 } from './types'
 export const name = 'chatluna-character'

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,4 +137,9 @@ export const usage = `
 `
 
 export { Config } from './config'
+export type {
+    CharacterAfterChatEventPayload,
+    CharacterBeforeChatEventPayload,
+    CharacterClearChatHistoryEventPayload
+} from './types'
 export const name = 'chatluna-character'

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -15,6 +15,9 @@ import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/mode
 import { parseRawModelName } from 'koishi-plugin-chatluna/llm-core/utils/count_tokens'
 import { Config } from '..'
 import {
+    CharacterBaseMessageSnapshot,
+    CharacterMessageSnapshot,
+    CharacterPresetSnapshot,
     ChatLunaChain,
     GroupTemp,
     GuildConfig,
@@ -75,6 +78,32 @@ interface NextReplyToolGroup {
 }
 
 const replyToolProgress = '__character_reply_progress__'
+
+function snapshotPreset(preset: PresetTemplate): CharacterPresetSnapshot {
+    return {
+        name: preset.name,
+        status: preset.status,
+        nick_name: preset.nick_name.slice(),
+        input: { rawString: preset.input.rawString },
+        system: { rawString: preset.system.rawString },
+        mute_keyword: preset.mute_keyword?.slice(),
+        path: preset.path
+    }
+}
+
+function snapshotMessage(value: Message): CharacterMessageSnapshot
+function snapshotMessage(value: Message[]): CharacterMessageSnapshot[]
+function snapshotMessage(value: Message | Message[]) {
+    return JSON.parse(JSON.stringify(value))
+}
+
+function snapshotBaseMessage(value: BaseMessage): CharacterBaseMessageSnapshot
+function snapshotBaseMessage(
+    value: BaseMessage[]
+): CharacterBaseMessageSnapshot[]
+function snapshotBaseMessage(value: BaseMessage | BaseMessage[]) {
+    return JSON.parse(JSON.stringify(value))
+}
 
 class PendingMessageQueue extends MessageQueue {
     private _messages: {
@@ -1617,18 +1646,10 @@ async function prepareMessages(
             }`,
             targetId: built.conversationId,
             presetName: currentPreset.name,
-            preset: {
-                name: currentPreset.name,
-                status: currentPreset.status,
-                nick_name: currentPreset.nick_name.slice(),
-                input: { rawString: currentPreset.input.rawString },
-                system: { rawString: currentPreset.system.rawString },
-                mute_keyword: currentPreset.mute_keyword?.slice(),
-                path: currentPreset.path
-            },
-            messages: JSON.parse(JSON.stringify(messages)),
+            preset: snapshotPreset(currentPreset),
+            messages: snapshotMessage(messages),
             focusMessage: focusMessage
-                ? JSON.parse(JSON.stringify(focusMessage))
+                ? snapshotMessage(focusMessage)
                 : undefined,
             triggerReason
         })
@@ -1766,7 +1787,7 @@ async function* streamModelResponse(
                                   config.toolCalling
                                   ? 'Your previous reply was not sent through `character_reply`, so it could not be delivered. ' +
                                         'Do not repeat completed external tool calls unless necessary. ' +
-                                        'Use the content from the previous reply and call `character_reply` now.'
+                                    'Use the content from the previous reply and call `character_reply` now.'
                                   : 'Your previous reply used an invalid format and could not be delivered. ' +
                                         'Reply again using valid XML output with <message> tags.'
                           )
@@ -2343,40 +2364,25 @@ export async function apply(ctx: Context, config: Config) {
                 nextReplyReasons
             )
 
-            await service.muteAtLeast(
-                session,
-                copyOfConfig.coolDownTime * 1000
-            )
+            await service.muteAtLeast(session, copyOfConfig.coolDownTime * 1000)
             await ctx.parallel('chatluna_character/after-chat', {
                 session,
                 sessionKey: key,
                 targetId: session.isDirect ? session.userId : session.guildId,
                 presetName: currentPreset.name,
-                preset: {
-                    name: currentPreset.name,
-                    status: currentPreset.status,
-                    nick_name: currentPreset.nick_name.slice(),
-                    input: { rawString: currentPreset.input.rawString },
-                    system: {
-                        rawString: currentPreset.system.rawString
-                    },
-                    mute_keyword: currentPreset.mute_keyword?.slice(),
-                    path: currentPreset.path
-                },
-                messages: JSON.parse(JSON.stringify(persistedMessages)),
+                preset: snapshotPreset(currentPreset),
+                messages: snapshotMessage(persistedMessages),
                 focusMessage: focusMessage
-                    ? JSON.parse(JSON.stringify(focusMessage))
+                    ? snapshotMessage(focusMessage)
                     : undefined,
                 triggerReason,
-                persistedHumanMessage: JSON.parse(
-                    JSON.stringify(persistedHumanMessage)
+                persistedHumanMessage: snapshotBaseMessage(
+                    persistedHumanMessage
                 ),
                 lastResponseMessage: lastResponseMessage
-                    ? JSON.parse(JSON.stringify(lastResponseMessage))
+                    ? snapshotBaseMessage(lastResponseMessage)
                     : undefined,
-                completionMessages: JSON.parse(
-                    JSON.stringify(temp.completionMessages)
-                ),
+                completionMessages: snapshotBaseMessage(temp.completionMessages),
                 status: latestStatus
             })
         } catch (e) {

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -2343,47 +2343,44 @@ export async function apply(ctx: Context, config: Config) {
                 nextReplyReasons
             )
 
-            service
-                .muteAtLeast(session, copyOfConfig.coolDownTime * 1000)
-                .then(() => {
-                    return ctx.parallel('chatluna_character/after-chat', {
-                        session,
-                        sessionKey: key,
-                        targetId: session.isDirect
-                            ? session.userId
-                            : session.guildId,
-                        presetName: currentPreset.name,
-                        preset: {
-                            name: currentPreset.name,
-                            status: currentPreset.status,
-                            nick_name: currentPreset.nick_name.slice(),
-                            input: { rawString: currentPreset.input.rawString },
-                            system: {
-                                rawString: currentPreset.system.rawString
-                            },
-                            mute_keyword: currentPreset.mute_keyword?.slice(),
-                            path: currentPreset.path
-                        },
-                        messages: JSON.parse(JSON.stringify(persistedMessages)),
-                        focusMessage: focusMessage
-                            ? JSON.parse(JSON.stringify(focusMessage))
-                            : undefined,
-                        triggerReason,
-                        persistedHumanMessage: JSON.parse(
-                            JSON.stringify(persistedHumanMessage)
-                        ),
-                        lastResponseMessage: lastResponseMessage
-                            ? JSON.parse(JSON.stringify(lastResponseMessage))
-                            : undefined,
-                        completionMessages: JSON.parse(
-                            JSON.stringify(temp.completionMessages)
-                        ),
-                        status: latestStatus
-                    })
-                })
-                .catch((error) => {
-                    logger.error(error)
-                })
+            await service.muteAtLeast(
+                session,
+                copyOfConfig.coolDownTime * 1000
+            )
+            ctx.parallel('chatluna_character/after-chat', {
+                session,
+                sessionKey: key,
+                targetId: session.isDirect ? session.userId : session.guildId,
+                presetName: currentPreset.name,
+                preset: {
+                    name: currentPreset.name,
+                    status: currentPreset.status,
+                    nick_name: currentPreset.nick_name.slice(),
+                    input: { rawString: currentPreset.input.rawString },
+                    system: {
+                        rawString: currentPreset.system.rawString
+                    },
+                    mute_keyword: currentPreset.mute_keyword?.slice(),
+                    path: currentPreset.path
+                },
+                messages: JSON.parse(JSON.stringify(persistedMessages)),
+                focusMessage: focusMessage
+                    ? JSON.parse(JSON.stringify(focusMessage))
+                    : undefined,
+                triggerReason,
+                persistedHumanMessage: JSON.parse(
+                    JSON.stringify(persistedHumanMessage)
+                ),
+                lastResponseMessage: lastResponseMessage
+                    ? JSON.parse(JSON.stringify(lastResponseMessage))
+                    : undefined,
+                completionMessages: JSON.parse(
+                    JSON.stringify(temp.completionMessages)
+                ),
+                status: latestStatus
+            }).catch((error) => {
+                logger.error(error)
+            })
         } catch (e) {
             logger.error(e)
         } finally {

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -1608,6 +1608,24 @@ async function prepareMessages(
     const persistedHumanMessage = new HumanMessage(
         prompt + (userPrompt.length > 0 ? `\n\n${userPrompt}` : '')
     )
+
+    try {
+        await ctx.parallel('chatluna_character/before-chat', {
+            session,
+            sessionKey: `${session.isDirect ? 'private' : 'group'}:${
+                session.isDirect ? session.userId : session.guildId
+            }`,
+            conversationId: built.conversationId,
+            presetName: currentPreset.name,
+            preset: currentPreset,
+            messages: messages.slice(),
+            focusMessage,
+            triggerReason
+        })
+    } catch (error) {
+        logger.error(error)
+    }
+
     const tempMessages: BaseMessage[] = []
 
     if (config.image) {
@@ -2315,7 +2333,29 @@ export async function apply(ctx: Context, config: Config) {
                 nextReplyReasons
             )
 
-            service.muteAtLeast(session, copyOfConfig.coolDownTime * 1000)
+            service
+                .muteAtLeast(session, copyOfConfig.coolDownTime * 1000)
+                .then(() =>
+                    ctx.parallel('chatluna_character/after-chat', {
+                        session,
+                        sessionKey: key,
+                        conversationId: session.isDirect
+                            ? session.userId
+                            : session.guildId,
+                        presetName: currentPreset.name,
+                        preset: currentPreset,
+                        messages: persistedMessages.slice(),
+                        focusMessage,
+                        triggerReason,
+                        persistedHumanMessage,
+                        lastResponseMessage,
+                        completionMessages: temp.completionMessages.slice(),
+                        status: latestStatus
+                    })
+                )
+                .catch((error) => {
+                    logger.error(error)
+                })
         } catch (e) {
             logger.error(e)
         } finally {

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -2347,7 +2347,7 @@ export async function apply(ctx: Context, config: Config) {
                 session,
                 copyOfConfig.coolDownTime * 1000
             )
-            ctx.parallel('chatluna_character/after-chat', {
+            void ctx.parallel('chatluna_character/after-chat', {
                 session,
                 sessionKey: key,
                 targetId: session.isDirect ? session.userId : session.guildId,

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -1615,11 +1615,21 @@ async function prepareMessages(
             sessionKey: `${session.isDirect ? 'private' : 'group'}:${
                 session.isDirect ? session.userId : session.guildId
             }`,
-            conversationId: built.conversationId,
+            targetId: built.conversationId,
             presetName: currentPreset.name,
-            preset: currentPreset,
-            messages: messages.slice(),
-            focusMessage,
+            preset: {
+                name: currentPreset.name,
+                status: currentPreset.status,
+                nick_name: currentPreset.nick_name.slice(),
+                input: { rawString: currentPreset.input.rawString },
+                system: { rawString: currentPreset.system.rawString },
+                mute_keyword: currentPreset.mute_keyword?.slice(),
+                path: currentPreset.path
+            },
+            messages: JSON.parse(JSON.stringify(messages)),
+            focusMessage: focusMessage
+                ? JSON.parse(JSON.stringify(focusMessage))
+                : undefined,
             triggerReason
         })
     } catch (error) {
@@ -2335,24 +2345,42 @@ export async function apply(ctx: Context, config: Config) {
 
             service
                 .muteAtLeast(session, copyOfConfig.coolDownTime * 1000)
-                .then(() =>
-                    ctx.parallel('chatluna_character/after-chat', {
+                .then(() => {
+                    return ctx.parallel('chatluna_character/after-chat', {
                         session,
                         sessionKey: key,
-                        conversationId: session.isDirect
+                        targetId: session.isDirect
                             ? session.userId
                             : session.guildId,
                         presetName: currentPreset.name,
-                        preset: currentPreset,
-                        messages: persistedMessages.slice(),
-                        focusMessage,
+                        preset: {
+                            name: currentPreset.name,
+                            status: currentPreset.status,
+                            nick_name: currentPreset.nick_name.slice(),
+                            input: { rawString: currentPreset.input.rawString },
+                            system: {
+                                rawString: currentPreset.system.rawString
+                            },
+                            mute_keyword: currentPreset.mute_keyword?.slice(),
+                            path: currentPreset.path
+                        },
+                        messages: JSON.parse(JSON.stringify(persistedMessages)),
+                        focusMessage: focusMessage
+                            ? JSON.parse(JSON.stringify(focusMessage))
+                            : undefined,
                         triggerReason,
-                        persistedHumanMessage,
-                        lastResponseMessage,
-                        completionMessages: temp.completionMessages.slice(),
+                        persistedHumanMessage: JSON.parse(
+                            JSON.stringify(persistedHumanMessage)
+                        ),
+                        lastResponseMessage: lastResponseMessage
+                            ? JSON.parse(JSON.stringify(lastResponseMessage))
+                            : undefined,
+                        completionMessages: JSON.parse(
+                            JSON.stringify(temp.completionMessages)
+                        ),
                         status: latestStatus
                     })
-                )
+                })
                 .catch((error) => {
                     logger.error(error)
                 })

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -2347,7 +2347,7 @@ export async function apply(ctx: Context, config: Config) {
                 session,
                 copyOfConfig.coolDownTime * 1000
             )
-            void ctx.parallel('chatluna_character/after-chat', {
+            await ctx.parallel('chatluna_character/after-chat', {
                 session,
                 sessionKey: key,
                 targetId: session.isDirect ? session.userId : session.guildId,
@@ -2378,8 +2378,6 @@ export async function apply(ctx: Context, config: Config) {
                     JSON.stringify(temp.completionMessages)
                 ),
                 status: latestStatus
-            }).catch((error) => {
-                logger.error(error)
             })
         } catch (e) {
             logger.error(e)

--- a/src/service/message.ts
+++ b/src/service/message.ts
@@ -450,7 +450,7 @@ export class MessageCollector extends Service {
         this.ctx
             .parallel('chatluna_character/clear-chat-history', {
                 sessionKey,
-                conversationId: isDirect
+                targetId: isDirect
                     ? sessionKey.slice('private:'.length)
                     : sessionKey.startsWith('group:')
                       ? sessionKey.slice('group:'.length)
@@ -515,7 +515,16 @@ export class MessageCollector extends Service {
         }
 
         // For clear-all, acquire locks in sorted order to prevent deadlocks
-        const groupIds = Object.keys(this._groupLocks).sort()
+        const groupIds = Array.from(
+            new Set([
+                ...Object.keys(this._messages),
+                ...Object.keys(this._groupLocks),
+                ...Object.keys(this._groupTemp),
+                ...Object.keys(this._responseWaiters),
+                ...Object.keys(this._pendingCooldownTriggers),
+                ...Object.keys(this._cooldownTriggerTimers)
+            ])
+        ).sort()
         const unlocks: (() => void)[] = []
         for (const gid of groupIds) {
             unlocks.push(await this._lockByGroupId(gid))

--- a/src/service/message.ts
+++ b/src/service/message.ts
@@ -445,6 +445,23 @@ export class MessageCollector extends Service {
         return this._getMutex(groupId).lock()
     }
 
+    private _emitClearChatHistory(sessionKey: string) {
+        const isDirect = sessionKey.startsWith('private:')
+        this.ctx
+            .parallel('chatluna_character/clear-chat-history', {
+                sessionKey,
+                conversationId: isDirect
+                    ? sessionKey.slice('private:'.length)
+                    : sessionKey.startsWith('group:')
+                      ? sessionKey.slice('group:'.length)
+                      : sessionKey,
+                isDirect
+            })
+            .catch((error) => {
+                this.logger.error(error)
+            })
+    }
+
     async clear(groupId?: string) {
         if (groupId) {
             const isDirect = groupId.startsWith('private:')
@@ -493,6 +510,7 @@ export class MessageCollector extends Service {
             } finally {
                 unlock()
             }
+            this._emitClearChatHistory(groupId)
             return
         }
 
@@ -558,6 +576,10 @@ export class MessageCollector extends Service {
             for (let i = unlocks.length - 1; i >= 0; i--) {
                 unlocks[i]()
             }
+        }
+
+        for (const groupId of groupIds) {
+            this._emitClearChatHistory(groupId)
         }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,6 +167,38 @@ export interface PresetTemplate {
     path?: string
 }
 
+export interface CharacterBeforeChatEventPayload {
+    session: Session
+    sessionKey: string
+    conversationId: string | undefined
+    presetName: string
+    preset: PresetTemplate
+    messages: Message[]
+    focusMessage?: Message
+    triggerReason?: string
+}
+
+export interface CharacterAfterChatEventPayload {
+    session: Session
+    sessionKey: string
+    conversationId: string | undefined
+    presetName: string
+    preset: PresetTemplate
+    messages: Message[]
+    focusMessage?: Message
+    triggerReason?: string
+    persistedHumanMessage: BaseMessage
+    lastResponseMessage?: BaseMessage
+    completionMessages: BaseMessage[]
+    status?: string | null
+}
+
+export interface CharacterClearChatHistoryEventPayload {
+    sessionKey: string
+    conversationId: string
+    isDirect: boolean
+}
+
 export interface GroupInfo {
     messageCount: number
     messageWait?: boolean
@@ -295,5 +327,17 @@ declare module 'koishi' {
     interface Tables {
         chathub_character_variable: CharacterVariableRecord
         chathub_character_wake_up_reply: WakeUpReplyRecord
+    }
+
+    interface Events {
+        'chatluna_character/before-chat': (
+            payload: CharacterBeforeChatEventPayload
+        ) => void | Promise<void>
+        'chatluna_character/after-chat': (
+            payload: CharacterAfterChatEventPayload
+        ) => void | Promise<void>
+        'chatluna_character/clear-chat-history': (
+            payload: CharacterClearChatHistoryEventPayload
+        ) => void | Promise<void>
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,36 +167,54 @@ export interface PresetTemplate {
     path?: string
 }
 
+export interface CharacterPromptTemplateSnapshot {
+    readonly rawString: string
+}
+
+export interface CharacterPresetSnapshot {
+    readonly name: string
+    readonly status?: string
+    readonly nick_name: readonly string[]
+    readonly input: CharacterPromptTemplateSnapshot
+    readonly system: CharacterPromptTemplateSnapshot
+    readonly mute_keyword?: readonly string[]
+    readonly path?: string
+}
+
+export type CharacterMessageSnapshot = Readonly<Message>
+
+export type CharacterBaseMessageSnapshot = Readonly<Record<string, unknown>>
+
 export interface CharacterBeforeChatEventPayload {
-    session: Session
-    sessionKey: string
-    conversationId: string | undefined
-    presetName: string
-    preset: PresetTemplate
-    messages: Message[]
-    focusMessage?: Message
-    triggerReason?: string
+    readonly session: Session
+    readonly sessionKey: string
+    readonly targetId: string | undefined
+    readonly presetName: string
+    readonly preset: CharacterPresetSnapshot
+    readonly messages: readonly CharacterMessageSnapshot[]
+    readonly focusMessage?: CharacterMessageSnapshot
+    readonly triggerReason?: string
 }
 
 export interface CharacterAfterChatEventPayload {
-    session: Session
-    sessionKey: string
-    conversationId: string | undefined
-    presetName: string
-    preset: PresetTemplate
-    messages: Message[]
-    focusMessage?: Message
-    triggerReason?: string
-    persistedHumanMessage: BaseMessage
-    lastResponseMessage?: BaseMessage
-    completionMessages: BaseMessage[]
-    status?: string | null
+    readonly session: Session
+    readonly sessionKey: string
+    readonly targetId: string | undefined
+    readonly presetName: string
+    readonly preset: CharacterPresetSnapshot
+    readonly messages: readonly CharacterMessageSnapshot[]
+    readonly focusMessage?: CharacterMessageSnapshot
+    readonly triggerReason?: string
+    readonly persistedHumanMessage: CharacterBaseMessageSnapshot
+    readonly lastResponseMessage?: CharacterBaseMessageSnapshot
+    readonly completionMessages: readonly CharacterBaseMessageSnapshot[]
+    readonly status?: string | null
 }
 
 export interface CharacterClearChatHistoryEventPayload {
-    sessionKey: string
-    conversationId: string
-    isDirect: boolean
+    readonly sessionKey: string
+    readonly targetId: string
+    readonly isDirect: boolean
 }
 
 export interface GroupInfo {


### PR DESCRIPTION
## 概览

为 Character 暴露最小生命周期事件，方便外部插件在不侵入 Character 内部逻辑的情况下适配对话流程。

新增 before-chat、after-chat 和 clear-chat-history 三个事件：

- `chatluna_character/before-chat`
- `chatluna_character/after-chat`
- `chatluna_character/clear-chat-history`
 
同时导出对应 payload 类型，方便外部插件复用类型定义。

before-chat 在 Character 完成消息准备、进入模型请求前触发，payload 仅包含会话、preset、消息快照和触发原因，不暴露 prompt 变量改写入口。

after-chat 在成功发送回复、注册后续触发并完成冷却设置后异步触发，携带持久化输入、最近回复、completion 消息和状态。

clear-chat-history 在单会话或全量清空历史后异步触发，并导出事件 payload 类型供外部插件复用。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three chat lifecycle events: before-chat, after-chat, and clear-chat-history — plugins can observe/preprocess messages, react to results, and respond when history is cleared.
  * Chat clearing now emits clear events for affected sessions/targets so integrations stay in sync.
  * Hooks are invoked defensively (errors are caught and logged) to avoid disrupting chat flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChatLunaLab/chatluna-character/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->