### PR TITLE
docs: clarify character reply parts usage

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -343,7 +343,13 @@ function createReplyTools(
             parts: {
                 type: 'array',
                 description:
-                    'Multiple parts inside one message, joined in order. Use this when you need to combine multiple elements (text, image, at, face) in a single message. Only the fields available in each part item are supported here; other element types (sticker, audio, file, video, voice, markdown) cannot be combined and must be sent as a standalone message.',
+                    'Multiple parts inside one message, joined in order. ' +
+                    'Use this when you need to combine multiple elements ' +
+                    '(text, image, at, face) in a single message. Only the ' +
+                    'fields available in each part item are supported here; ' +
+                    'other element types (sticker, audio, file, video, ' +
+                    'voice, markdown) cannot be combined and must be sent ' +
+                    'as a standalone message.',
                 items: {
                     ...part
                 }
@@ -440,7 +446,16 @@ function createReplyTools(
         messages: {
             type: 'array',
             description:
-                'List of messages to send. Each object in the array is one message. Use an empty array when no reply is needed. IMPORTANT: Each message object only supports ONE top-level content field (text, image, sticker, audio, file, video, voice, markdown, or at). Do NOT combine multiple content fields in the same message object outside of `parts`; only the first matching field will be used and the rest will be silently ignored. To send a message containing multiple elements (e.g. text + image, text + at), you MUST use the `parts` array.',
+                'List of messages to send. Each object in the array is one ' +
+                'message. Use an empty array when no reply is needed. ' +
+                'IMPORTANT: Each message object only supports ONE top-level ' +
+                'content field (text, image, sticker, audio, file, video, ' +
+                'voice, markdown, or at). Do NOT combine multiple content ' +
+                'fields in the same message object outside of `parts`; only ' +
+                'the first matching field will be used and the rest will be ' +
+                'silently ignored. To send a message containing multiple ' +
+                'elements (e.g. text + image, text + at), you MUST use the ' +
+                '`parts` array.',
             items: {
                 ...message
             }

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -343,7 +343,7 @@ function createReplyTools(
             parts: {
                 type: 'array',
                 description:
-                    'Multiple parts inside one message, joined in order.',
+                    'Multiple parts inside one message, joined in order. Use this when you need to combine multiple elements (text, image, at, face) in a single message. Only the fields available in each part item are supported here; other element types (sticker, audio, file, video, voice, markdown) cannot be combined and must be sent as a standalone message.',
                 items: {
                     ...part
                 }
@@ -440,7 +440,7 @@ function createReplyTools(
         messages: {
             type: 'array',
             description:
-                'List of messages to send. Each object in the array is one message. Use an empty array when no reply is needed.',
+                'List of messages to send. Each object in the array is one message. Use an empty array when no reply is needed. IMPORTANT: Each message object only supports ONE top-level content field (text, image, sticker, audio, file, video, voice, markdown, or at). Do NOT combine multiple content fields in the same message object outside of `parts`; only the first matching field will be used and the rest will be silently ignored. To send a message containing multiple elements (e.g. text + image, text + at), you MUST use the `parts` array.',
             items: {
                 ...message
             }


### PR DESCRIPTION
## 概要

- 补充 `character_reply.messages` 的描述，说明同一消息对象顶层只能使用一个内容字段。
- 补充 `parts` 的描述，说明组合多个元素时必须使用 `parts`，且 `sticker`、`audio`、`file`、`video`、`voice`、`markdown` 等元素必须单独发送。

## 校验

- `yarn fast-build`
- `npx tsc --noEmit`
