### PR TITLE
docs: clarify character reply field priority

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -446,16 +446,7 @@ function createReplyTools(
         messages: {
             type: 'array',
             description:
-                'List of messages to send. Each object in the array is one ' +
-                'message. Use an empty array when no reply is needed. ' +
-                'IMPORTANT: Each message object only supports ONE top-level ' +
-                'content field (parts, at, face, sticker, image, audio, ' +
-                'file, video, markdown, voice, or text). Do NOT combine ' +
-                'multiple content fields in the same message object outside ' +
-                'of `parts`; if you do, only the first field in that priority ' +
-                'order will be used and the rest will be silently ignored. ' +
-                'To send a message containing multiple elements (e.g. ' +
-                'text + image, text + at), you MUST use the `parts` array.',
+                'List of messages to send. Each object in the array is one message. Use an empty array when no reply is needed. IMPORTANT: Each message object only supports ONE top-level content field (parts, at, face, sticker, image, audio, file, video, markdown, voice, or text). Do NOT combine multiple content fields in the same message object outside of `parts`; if you do, only the first field in that priority order will be used and the rest will be silently ignored. To send a message containing multiple elements (e.g. text + image, text + at), you MUST use the `parts` array.',
             items: {
                 ...message
             }

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -449,13 +449,13 @@ function createReplyTools(
                 'List of messages to send. Each object in the array is one ' +
                 'message. Use an empty array when no reply is needed. ' +
                 'IMPORTANT: Each message object only supports ONE top-level ' +
-                'content field (text, image, sticker, audio, file, video, ' +
-                'voice, markdown, or at). Do NOT combine multiple content ' +
-                'fields in the same message object outside of `parts`; only ' +
-                'the first matching field will be used and the rest will be ' +
-                'silently ignored. To send a message containing multiple ' +
-                'elements (e.g. text + image, text + at), you MUST use the ' +
-                '`parts` array.',
+                'content field (parts, at, face, sticker, image, audio, ' +
+                'file, video, markdown, voice, or text). Do NOT combine ' +
+                'multiple content fields in the same message object outside ' +
+                'of `parts`; if you do, only the first field in that priority ' +
+                'order will be used and the rest will be silently ignored. ' +
+                'To send a message containing multiple elements (e.g. ' +
+                'text + image, text + at), you MUST use the `parts` array.',
             items: {
                 ...message
             }

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -343,13 +343,7 @@ function createReplyTools(
             parts: {
                 type: 'array',
                 description:
-                    'Multiple parts inside one message, joined in order. ' +
-                    'Use this when you need to combine multiple elements ' +
-                    '(text, image, at, face) in a single message. Only the ' +
-                    'fields available in each part item are supported here; ' +
-                    'other element types (sticker, audio, file, video, ' +
-                    'voice, markdown) cannot be combined and must be sent ' +
-                    'as a standalone message.',
+                    'Use this to combine multiple elements (text, image, at, face) in one message. Other element types (sticker, audio, file, video, voice, markdown) cannot appear in parts and must be sent as a standalone message.',
                 items: {
                     ...part
                 }
@@ -446,7 +440,7 @@ function createReplyTools(
         messages: {
             type: 'array',
             description:
-                'List of messages to send. Each object in the array is one message. Use an empty array when no reply is needed. IMPORTANT: Each message object only supports ONE top-level content field (parts, at, face, sticker, image, audio, file, video, markdown, voice, or text). Do NOT combine multiple content fields in the same message object outside of `parts`; if you do, only the first field in that priority order will be used and the rest will be silently ignored. To send a message containing multiple elements (e.g. text + image, text + at), you MUST use the `parts` array.',
+                'List of messages to send. Each message object uses only one content field at a time. To combine multiple elements in one message, use `parts`. Use an empty array when no reply is needed.',
             items: {
                 ...message
             }


### PR DESCRIPTION
## 概要

- 根据机器人评论补充 `face` 到 `character_reply.messages` 的顶层内容字段说明中。
- 将多个顶层字段冲突时的说明调整为实际处理优先级，避免模型误解“第一个字段”的含义。

## 校验

- `yarn fast-build`
- `npx tsc --noEmit`
