### PR TITLE
chore(package): bump version to 0.0.217

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-character",
     "description": "Let the large language model play a role, disguise as a group friend",
-    "version": "0.0.216",
+    "version": "0.0.217",
     "type": "module",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",


### PR DESCRIPTION
## 概要

- 将 `package.json` 版本号从 `0.0.216` 提升到 `0.0.217`，用于触发 npm 发布流程。

## 校验

- `yarn fast-build`
- `npx tsc --noEmit`
