### PR TITLE
fix: unify reply tool message content format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,10 @@ export const usage = `
 ### 26.05.19
 
 新增 \`<audio>\` 音频文件消息，支持 XML 与工具调用输出；\`<voice>\` 仍仅用于 TTS。详见文档。
+
+### 26.05.28
+
+优化 \`character_reply\` 工具调用回复格式：每条消息统一使用 \`content\` 元素列表，单元素消息与多元素消息使用同一种结构。
 `
 
 export { Config } from './config'

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -332,132 +332,78 @@ function createReplyTools(
 ): StructuredTool[] {
     const canAt = !session.isDirect && 'isAt' in config && config.isAt
     const canFace = session.platform === 'qq' || session.platform === 'onebot'
-    const part = {
+    const elementTypes = ['text', 'image', 'sticker', 'audio']
+    const element = {
         type: 'object',
         properties: {
+            type: {
+                type: 'string',
+                enum: elementTypes,
+                description: 'Element type'
+            },
             text: {
                 type: 'string',
-                description: 'Text content'
+                description:
+                    'Text for type=text, type=markdown, or type=voice'
             },
-            image: {
+            url: {
                 type: 'string',
-                description: 'HTTP(S) image URL'
+                description:
+                    'HTTP(S) URL for type=image, type=sticker, type=audio, type=file, or type=video'
+            },
+            id: {
+                type: 'string',
+                description: 'User ID for type=at, QQ face ID for type=face, or optional voice ID for type=voice'
+            },
+            name: {
+                type: 'string',
+                description: 'File name for type=file'
             }
-        }
+        },
+        required: ['type']
     }
 
     const message = {
         type: 'object',
         properties: {
-            text: {
-                type: 'string',
-                description: 'Text content'
-            },
             quote: {
                 type: 'string',
                 description: 'Platform message ID to quote'
             },
-            sticker: {
-                type: 'string',
-                description: 'HTTP(S) sticker URL'
-            },
-            image: {
-                type: 'string',
-                description: 'HTTP(S) image URL'
-            },
-            audio: {
-                type: 'string',
-                description: 'HTTP(S) audio URL to send as a voice message'
-            },
-            parts: {
+            content: {
                 type: 'array',
                 description:
-                    'Use this to combine multiple elements (text, image, at, face) in one message. Other element types (sticker, audio, file, video, voice, markdown) cannot appear in parts and must be sent as a standalone message.',
+                    'Ordered elements inside this message. text, image, at, and face can coexist. sticker, audio, file, video, voice, and markdown must be the sole element.',
                 items: {
-                    ...part
+                    ...element
                 }
             }
-        }
+        },
+        required: ['content']
     }
 
     if (canAt) {
-        part.properties['at'] = {
-            type: 'string',
-            description: 'Platform ID of the user to mention.'
-        }
-        message.properties['at'] = {
-            type: 'string',
-            description: 'Platform ID of the user to mention.'
-        }
+        elementTypes.push('at')
     }
 
     if (canFace) {
-        part.properties['face'] = {
-            type: 'string',
-            description: 'QQ face ID'
-        }
-        message.properties['face'] = {
-            type: 'string',
-            description: 'QQ face ID'
-        }
+        elementTypes.push('face')
     }
 
     if (ctx.vits) {
-        message.properties['voice'] = {
-            type: 'object',
-            description: 'Voice message',
-            properties: {
-                text: {
-                    type: 'string',
-                    description: 'Text to synthesize into voice'
-                },
-                id: {
-                    type: 'string',
-                    description: 'Optional voice ID'
-                }
-            },
-            required: ['text']
-        }
+        elementTypes.push('voice')
     }
 
     if (session.platform !== 'qq') {
-        message.properties['file'] = {
-            type: 'object',
-            description: 'File message',
-            properties: {
-                name: {
-                    type: 'string',
-                    description: 'File name'
-                },
-                url: {
-                    type: 'string',
-                    description: 'HTTP(S) file URL'
-                }
-            },
-            required: ['name', 'url']
-        }
+        elementTypes.push('file')
 
         if (session.platform === 'onebot') {
-            message.properties['video'] = {
-                type: 'object',
-                description:
-                    'Video message. Prefer this for videos within 100MB, but metadata may be lost. Use file for larger videos.',
-                properties: {
-                    url: {
-                        type: 'string',
-                        description: 'HTTP(S) video URL'
-                    }
-                },
-                required: ['url']
-            }
+            elementTypes.push('video')
         }
     }
 
     if (session.platform === 'qq' && session.isDirect) {
-        message.properties['markdown'] = {
-            type: 'string',
-            description: 'Markdown content, including LaTeX'
-        }
+        elementTypes.push('markdown')
     }
 
     const props: Record<string, unknown> = {
@@ -469,7 +415,7 @@ function createReplyTools(
         messages: {
             type: 'array',
             description:
-                'List of messages to send. Each message object uses only one content field at a time. To combine multiple elements in one message, use `parts`. Use an empty array when no reply is needed.',
+                'Chat bubbles to send. Each item is one message. Use an empty array when no reply is needed.',
             items: {
                 ...message
             }
@@ -594,7 +540,7 @@ function createReplyTools(
                 {
                     name: 'character_reply',
                     description:
-                        'Send one or more in-character reply messages and required actions. All user-visible reply content must be sent through this tool. Use the literal string `\\n` for line breaks in all string fields. Do not use real newline characters. Do not manually wrap content in XML tags inside any field. Fill the structured fields directly. Do not end the turn with plain text output outside this tool.',
+                        'Send in-character reply messages. Use the literal string `\\n` for line breaks in all string fields. Do not use real newline characters. Do not wrap content in XML tags inside any field.',
                     returnDirect: false,
                     verboseParsingErrors: true,
                     schema: {
@@ -863,29 +809,63 @@ function buildXmlMessage(args: Record<string, unknown>) {
         return text.replaceAll('"', '&quot;')
     }
 
-    const buildPart = (part: Record<string, unknown>) => {
-        let result = ''
-
-        if (typeof part.text === 'string') {
-            result += escape(part.text)
+    const buildElement = (el: Record<string, unknown>) => {
+        if (el.type === 'text') {
+            return escape(el.text)
         }
 
-        if (typeof part.at === 'string') {
-            result += `<at>${escape(part.at)}</at>`
+        if (el.type === 'at') {
+            return `<at>${escape(el.id)}</at>`
         }
 
-        if (typeof part.face === 'string') {
-            result += `<face>${escape(part.face)}</face>`
+        if (el.type === 'face') {
+            return `<face>${escape(el.id)}</face>`
         }
 
-        if (typeof part.image === 'string') {
-            if (!isHttpUrl(part.image)) {
-                return result
+        if (el.type === 'sticker') {
+            if (!isHttpUrl(el.url)) {
+                return ''
             }
-            result += `<image>${escape(part.image)}</image>`
+            return `<sticker>${escape(el.url)}</sticker>`
         }
 
-        return result
+        if (el.type === 'image') {
+            if (!isHttpUrl(el.url)) {
+                return ''
+            }
+            return `<image>${escape(el.url)}</image>`
+        }
+
+        if (el.type === 'audio') {
+            if (!isHttpUrl(el.url)) {
+                return ''
+            }
+            return `<audio>${escape(el.url)}</audio>`
+        }
+
+        if (el.type === 'file') {
+            if (!isHttpUrl(el.url)) {
+                return ''
+            }
+            return `<file name="${escape(el.name ?? 'file', true)}">${escape(el.url)}</file>`
+        }
+
+        if (el.type === 'video') {
+            if (!isHttpUrl(el.url)) {
+                return ''
+            }
+            return `<video>${escape(el.url)}</video>`
+        }
+
+        if (el.type === 'markdown') {
+            return `<markdown>${escape(el.text)}</markdown>`
+        }
+
+        if (el.type === 'voice') {
+            return `<voice id="${escape(el.id, true)}">${escape(el.text)}</voice>`
+        }
+
+        return ''
     }
 
     const quote =
@@ -893,85 +873,19 @@ function buildXmlMessage(args: Record<string, unknown>) {
             ? ` quote="${escape(args.quote, true)}"`
             : ''
 
-    if (Array.isArray(args.parts)) {
-        const content = args.parts
+    if (Array.isArray(args.content)) {
+        const content = args.content
             .filter(
                 (item) =>
                     item && typeof item === 'object' && !Array.isArray(item)
             )
-            .map((item) => buildPart(item as Record<string, unknown>))
+            .map((item) => buildElement(item as Record<string, unknown>))
             .join('')
 
         return `<message${quote}>${content}</message>`
     }
 
-    if (typeof args.at === 'string') {
-        return `<message${quote}><at>${escape(args.at)}</at></message>`
-    }
-
-    if (typeof args.face === 'string') {
-        return `<message${quote}><face>${escape(args.face)}</face></message>`
-    }
-
-    if (typeof args.sticker === 'string') {
-        if (!isHttpUrl(args.sticker)) {
-            return `<message${quote}></message>`
-        }
-        return `<message${quote}><sticker>${escape(args.sticker)}</sticker></message>`
-    }
-
-    if (typeof args.image === 'string') {
-        if (!isHttpUrl(args.image)) {
-            return `<message${quote}></message>`
-        }
-        return `<message${quote}><image>${escape(args.image)}</image></message>`
-    }
-
-    if (typeof args.audio === 'string') {
-        if (!isHttpUrl(args.audio)) {
-            return `<message${quote}></message>`
-        }
-        return `<message${quote}><audio>${escape(args.audio)}</audio></message>`
-    }
-
-    if (
-        args.file &&
-        typeof args.file === 'object' &&
-        !Array.isArray(args.file)
-    ) {
-        const file = args.file as Record<string, unknown>
-        if (!isHttpUrl(file.url)) {
-            return `<message${quote}></message>`
-        }
-        return `<message${quote}><file name="${escape(file.name ?? 'file', true)}">${escape(file.url)}</file></message>`
-    }
-
-    if (
-        args.video &&
-        typeof args.video === 'object' &&
-        !Array.isArray(args.video)
-    ) {
-        const video = args.video as Record<string, unknown>
-        if (!isHttpUrl(video.url)) {
-            return `<message${quote}></message>`
-        }
-        return `<message${quote}><video>${escape(video.url)}</video></message>`
-    }
-
-    if (typeof args.markdown === 'string') {
-        return `<message${quote}><markdown>${escape(args.markdown)}</markdown></message>`
-    }
-
-    if (
-        args.voice &&
-        typeof args.voice === 'object' &&
-        !Array.isArray(args.voice)
-    ) {
-        const voice = args.voice as Record<string, unknown>
-        return `<message${quote}><voice id="${escape(voice.id, true)}">${escape(voice.text)}</voice></message>`
-    }
-
-    return `<message${quote}>${escape(args.text)}</message>`
+    return `<message${quote}></message>`
 }
 
 function parseReplyTools(

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -333,6 +333,31 @@ function createReplyTools(
     const canAt = !session.isDirect && 'isAt' in config && config.isAt
     const canFace = session.platform === 'qq' || session.platform === 'onebot'
     const elementTypes = ['text', 'image', 'sticker', 'audio']
+
+    if (canAt) {
+        elementTypes.push('at')
+    }
+
+    if (canFace) {
+        elementTypes.push('face')
+    }
+
+    if (ctx.vits) {
+        elementTypes.push('voice')
+    }
+
+    if (session.platform !== 'qq') {
+        elementTypes.push('file')
+
+        if (session.platform === 'onebot') {
+            elementTypes.push('video')
+        }
+    }
+
+    if (session.platform === 'qq' && session.isDirect) {
+        elementTypes.push('markdown')
+    }
+
     const element = {
         type: 'object',
         properties: {
@@ -380,30 +405,6 @@ function createReplyTools(
             }
         },
         required: ['content']
-    }
-
-    if (canAt) {
-        elementTypes.push('at')
-    }
-
-    if (canFace) {
-        elementTypes.push('face')
-    }
-
-    if (ctx.vits) {
-        elementTypes.push('voice')
-    }
-
-    if (session.platform !== 'qq') {
-        elementTypes.push('file')
-
-        if (session.platform === 'onebot') {
-            elementTypes.push('video')
-        }
-    }
-
-    if (session.platform === 'qq' && session.isDirect) {
-        elementTypes.push('markdown')
     }
 
     const props: Record<string, unknown> = {


### PR DESCRIPTION
## 摘要

- 将 `character_reply.messages[].content` 统一为消息元素列表，单元素与多元素消息使用同一种结构。
- 用 `type` 区分 text、image、sticker、audio、at、face、voice、file、video、markdown 等元素。
- 精简工具描述和运行时提示，减少重复说明。
- 更新插件 usage，说明新的工具调用回复格式。

## 校验

- `yarn tsc --noEmit`
- `yarn fast-build`
- 已同步到本地 Koishi 插件目录并重启 Koishi 容器。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a dated entry explaining the updated character reply message format and its usage.

* **Refactor**
  * Unified message replies to use an ordered content-element list for all message types (text, images, audio, video, stickers, files, etc.), improving consistency of displayed replies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChatLunaLab/chatluna-character/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->