### PR TITLE
chore(package): bump version to 0.0.218

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-character",
     "description": "Let the large language model play a role, disguise as a group friend",
-    "version": "0.0.217",
+    "version": "0.0.218",
     "type": "module",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",


### PR DESCRIPTION
## 摘要

- 将 `package.json` 版本号从 `0.0.217` 提升到 `0.0.218`。

## 说明

- npm 当前版本：`0.0.217`。
- 合并到 `main` 后将触发发布工作流。

## 校验

- 版本号变更，仅修改 `package.json`。
