### PR TITLE
fix: persist empty XML action replies

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -2216,17 +2216,24 @@ export async function apply(ctx: Context, config: Config) {
                         ctx,
                         chunk.parsedResponse
                     )
-
-                    if (!sendResult.sentAny) {
-                        continue
-                    }
-
-                    sentAny = true
-                    lastResponseMessage =
+                    const responseMessage =
                         copyOfConfig.experimentalToolCallReply &&
                         chunk.toolCalls?.length
                             ? new AIMessage(chunk.responseContent)
                             : chunk.responseMessage
+
+                    if (!sendResult.sentAny) {
+                        if (
+                            isEmptyReply &&
+                            /<action\b/i.test(chunk.responseContent)
+                        ) {
+                            lastResponseMessage = responseMessage
+                        }
+                        continue
+                    }
+
+                    sentAny = true
+                    lastResponseMessage = responseMessage
                     await ctx.chatluna_character.broadcastOnBot(
                         session,
                         sendResult.sentMessages
@@ -2240,7 +2247,7 @@ export async function apply(ctx: Context, config: Config) {
                 service.stopPendingMessages(session)
             }
 
-            if (!sentAny) {
+            if (!sentAny && !lastResponseMessage) {
                 if (hasEmptyReplies && !hasNonEmptyReplies) {
                     await registerResponseTriggers(
                         ctx,


### PR DESCRIPTION
## 摘要

- 修复空 `<message>` 携带 `<action>` 时不会进入 `completionMessages` 的问题。
- 在没有实际发送消息但存在 XML action 时，仍保留本轮 AI 回复用于后续 XML 扫描。
- 保持普通纯空回复不持久化，避免改变无关行为。

## 验证

- `yarn tsc --noEmit`
- `yarn fast-build`

Fixes #96
