### PR TITLE
fix: 区分回复工具重试错误

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -59,6 +59,7 @@ interface StreamedResponseContentChunk {
     responseContent: string
     isIntermediate: boolean
     toolCalls?: ReplyToolCall[]
+    toolErrors?: string[]
 }
 
 interface ReplyToolCall {
@@ -1048,9 +1049,10 @@ async function parseResponseContent(
 ): Promise<StreamedParsedResponseChunk> {
     let parsedResponse: ParsedResponse
     const { responseMessage, responseContent, isIntermediate } = chunk
+    const toolErrors = chunk.toolErrors ?? []
     const calls =
         config.experimentalToolCallReply && chunk.toolCalls?.length > 0
-            ? filterReplyToolCalls(config, chunk.toolCalls)
+            ? filterReplyToolCalls(config, chunk.toolCalls, toolErrors)
             : undefined
     const toolState =
         calls && calls.length > 0 ? parseReplyTools(config, calls) : undefined
@@ -1058,6 +1060,23 @@ async function parseResponseContent(
     const renderedContent = hasCalls
         ? renderReplyToolXml(ctx, session, config, calls)
         : responseContent
+
+    if (!hasCalls && toolErrors.length > 0) {
+        throw new Error(
+            `Failed to parse response: invalid character_reply tool call. ${toolErrors.join('; ')}`
+        )
+    }
+
+    if (
+        config.experimentalToolCallReply &&
+        config.toolCalling &&
+        !hasCalls &&
+        !isIntermediate
+    ) {
+        throw new Error(
+            'Failed to parse response: missing character_reply tool call'
+        )
+    }
 
     if (
         !toolState &&
@@ -1201,10 +1220,15 @@ async function* streamAgentResponseContents(
     )
 
     for await (const responseChunk of responseStream) {
+        const toolErrors: string[] = []
         const calls =
             config.experimentalToolCallReply &&
             responseChunk.toolCalls?.length > 0
-                ? filterReplyToolCalls(config, responseChunk.toolCalls)
+                ? filterReplyToolCalls(
+                      config,
+                      responseChunk.toolCalls,
+                      toolErrors
+                  )
                 : responseChunk.toolCalls
 
         if (
@@ -1244,6 +1268,20 @@ async function* streamAgentResponseContents(
                 ? renderReplyToolXml(ctx, session, config, calls)
                 : responseContent
         if (renderedContent.trim().length < 1) {
+            if (toolErrors.length > 0) {
+                throw new Error(
+                    `Failed to parse response: invalid character_reply tool call. ${toolErrors.join('; ')}`
+                )
+            }
+            if (
+                config.experimentalToolCallReply &&
+                responseChunk.phase === 'final' &&
+                !finalReply
+            ) {
+                throw new Error(
+                    'Failed to parse response: missing character_reply tool call'
+                )
+            }
             continue
         }
 
@@ -1257,7 +1295,8 @@ async function* streamAgentResponseContents(
             responseMessage,
             responseContent: renderedContent,
             isIntermediate,
-            toolCalls: calls
+            toolCalls: calls,
+            toolErrors
         }
     }
 }
@@ -1692,20 +1731,33 @@ async function* streamModelResponse(
     let failedMessage: BaseMessage | undefined
     for (let idx = 0; idx < 2; idx++) {
         try {
+            const errText = String(err)
+            const retryPrompt =
+                config.experimentalToolCallReply && config.toolCalling
+                    ? errText.includes('invalid character_reply tool call')
+                        ? `Your previous \`character_reply\` tool call was invalid, so it could not be delivered.
+The parser error was: ${errText}.
+Fix the missing or invalid fields named in the parser error.
+Do not repeat completed external tool calls unless necessary.
+Use the content from the previous reply and call \`character_reply\` again.`
+                        : errText.includes('missing character_reply tool call')
+                          ? `Your previous reply did not call \`character_reply\`, so it could not be delivered.
+The parser error was: ${errText}.
+Do not repeat completed external tool calls unless necessary.
+Use the content from the previous reply and send it through \`character_reply\` now.`
+                          : `Your previous reply could not be delivered through \`character_reply\`.
+The parser error was: ${errText}.
+Do not repeat completed external tool calls unless necessary.
+Use the content from the previous reply and call \`character_reply\` now.`
+                    : `Your previous reply used an invalid format and could not be delivered.
+The parser error was: ${errText}.
+Reply again using valid XML output with <message> tags.`
             const messages =
-                idx === 0 || !String(err).includes('Failed to parse response')
+                idx === 0 || !errText.includes('Failed to parse response')
                     ? completionMessages
                     : completionMessages.concat(
                           ...(failedMessage ? [failedMessage] : []),
-                          new HumanMessage(
-                              config.experimentalToolCallReply &&
-                                  config.toolCalling
-                                  ? 'Your previous reply was not sent through `character_reply`, so it could not be delivered. ' +
-                                        'Do not repeat completed external tool calls unless necessary. ' +
-                                    'Use the content from the previous reply and call `character_reply` now.'
-                                  : 'Your previous reply used an invalid format and could not be delivered. ' +
-                                        'Reply again using valid XML output with <message> tags.'
-                          )
+                          new HumanMessage(retryPrompt)
                       )
             const lastMessage = messages[messages.length - 1]
             const historyMessages = messages.slice(0, -1)
@@ -2363,7 +2415,8 @@ function getReplyToolInputError(
 
 function filterReplyToolCalls(
     config: Config | GuildConfig | PrivateConfig,
-    calls: ReplyToolCall[]
+    calls: ReplyToolCall[],
+    errors?: string[]
 ) {
     return calls.filter((call) => {
         if (call.name !== 'character_reply') {
@@ -2372,6 +2425,7 @@ function filterReplyToolCalls(
 
         const err = getReplyToolInputError(config, call.args)
         if (err) {
+            errors?.push(err)
             logger.debug(`Skip invalid character_reply tool call: ${err}`)
             return false
         }

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -1731,34 +1731,40 @@ async function* streamModelResponse(
     let failedMessage: BaseMessage | undefined
     for (let idx = 0; idx < 2; idx++) {
         try {
-            const errText = String(err)
-            const retryPrompt =
-                config.experimentalToolCallReply && config.toolCalling
-                    ? errText.includes('invalid character_reply tool call')
-                        ? `Your previous \`character_reply\` tool call was invalid, so it could not be delivered.
+            let messages = completionMessages
+            if (idx > 0) {
+                const errText = String(err)
+                if (errText.includes('Failed to parse response')) {
+                    const retryPrompt =
+                        config.experimentalToolCallReply && config.toolCalling
+                            ? errText.includes(
+                                  'invalid character_reply tool call'
+                              )
+                                ? `Your previous \`character_reply\` tool call was invalid, so it could not be delivered.
 The parser error was: ${errText}.
 Fix the missing or invalid fields named in the parser error.
 Do not repeat completed external tool calls unless necessary.
 Use the content from the previous reply and call \`character_reply\` again.`
-                        : errText.includes('missing character_reply tool call')
-                          ? `Your previous reply did not call \`character_reply\`, so it could not be delivered.
+                                : errText.includes(
+                                        'missing character_reply tool call'
+                                    )
+                                  ? `Your previous reply did not call \`character_reply\`, so it could not be delivered.
 The parser error was: ${errText}.
 Do not repeat completed external tool calls unless necessary.
 Use the content from the previous reply and send it through \`character_reply\` now.`
-                          : `Your previous reply could not be delivered through \`character_reply\`.
+                                  : `Your previous reply could not be delivered through \`character_reply\`.
 The parser error was: ${errText}.
 Do not repeat completed external tool calls unless necessary.
 Use the content from the previous reply and call \`character_reply\` now.`
-                    : `Your previous reply used an invalid format and could not be delivered.
+                            : `Your previous reply used an invalid format and could not be delivered.
 The parser error was: ${errText}.
 Reply again using valid XML output with <message> tags.`
-            const messages =
-                idx === 0 || !errText.includes('Failed to parse response')
-                    ? completionMessages
-                    : completionMessages.concat(
-                          ...(failedMessage ? [failedMessage] : []),
-                          new HumanMessage(retryPrompt)
-                      )
+                    messages = completionMessages.concat(
+                        ...(failedMessage ? [failedMessage] : []),
+                        new HumanMessage(retryPrompt)
+                    )
+                }
+            }
             const lastMessage = messages[messages.length - 1]
             const historyMessages = messages.slice(0, -1)
 
@@ -1812,9 +1818,11 @@ Reply again using valid XML output with <message> tags.`
             if (idx < 1) {
                 err = e
                 logger.warn('model response failed, retry once', e)
+                await sleep(3000)
                 continue
             }
             logger.error('model requests failed', e)
+            throw e
         }
     }
 }

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -1818,7 +1818,6 @@ Reply again using valid XML output with <message> tags.`
             if (idx < 1) {
                 err = e
                 logger.warn('model response failed, retry once', e)
-                await sleep(3000)
                 continue
             }
             logger.error('model requests failed', e)


### PR DESCRIPTION
## 变更内容

- 区分 `experimentalToolCallReply` 下最终回复失败的两种情况：完全未调用 `character_reply`，以及调用了但参数缺失或类型错误。
- 将无效 `character_reply` 的校验错误传入解析失败错误中，例如 `Missing required field(s): ...`。
- 重试提示按错误类型分别生成，缺参时明确要求模型补齐错误中点名的字段。

## 验证

- `yarn tsc --noEmit`
- `yarn fast-build`
- 已同步到本地 Koishi 插件目录并重启 `koishi`
- 已校验源码构建产物与 Koishi 插件目录 `lib/index.cjs` 的 sha256 一致


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and propagation of tool-call parsing errors during streaming, causing clearer failures when tool-call payloads are invalid or missing.
* **Behaviour**
  * Smarter retry logic: tailored retry prompts based on error type, appended context for retries, a short backoff before retrying, and clearer rethrowing after retry exhaustion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->