### PR TITLE
fix: abort agent stream on consumer exit

### DIFF
--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -254,8 +254,19 @@ export async function createChatLunaChain(
             }
 
             const chunkQueue = createAsyncChunkQueue<ChatLunaChainStreamChunk>()
+            const ctl = new AbortController()
             let buf = ''
             const toolCalls: ChatLunaChainStreamChunk['toolCalls'] = []
+
+            if (options?.signal?.aborted) {
+                ctl.abort()
+            } else {
+                options?.signal?.addEventListener(
+                    'abort',
+                    () => ctl.abort(),
+                    { once: true }
+                )
+            }
 
             const emitEarlyIntermediate = (action: AgentStep['action']) => {
                 const chunk = createAgentResponseChunk(
@@ -292,6 +303,7 @@ export async function createChatLunaChain(
 
             const streamOptions: ChatLunaRunnableConfig = {
                 ...(options ?? {}),
+                signal: ctl.signal,
                 configurable: {
                     ...(options?.configurable ?? {}),
                     ...(toolMask != null ? { toolMask } : {})
@@ -388,6 +400,7 @@ export async function createChatLunaChain(
                     if (value) yield value
                 }
             } finally {
+                ctl.abort()
                 await producer
             }
         }

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -257,15 +257,14 @@ export async function createChatLunaChain(
             const ctl = new AbortController()
             let buf = ''
             const toolCalls: ChatLunaChainStreamChunk['toolCalls'] = []
+            const onAbort = () => ctl.abort()
 
             if (options?.signal?.aborted) {
                 ctl.abort()
             } else {
-                options?.signal?.addEventListener(
-                    'abort',
-                    () => ctl.abort(),
-                    { once: true }
-                )
+                options?.signal?.addEventListener('abort', onAbort, {
+                    once: true
+                })
             }
 
             const emitEarlyIntermediate = (action: AgentStep['action']) => {
@@ -400,6 +399,7 @@ export async function createChatLunaChain(
                     if (value) yield value
                 }
             } finally {
+                options?.signal?.removeEventListener('abort', onAbort)
                 ctl.abort()
                 await producer
             }


### PR DESCRIPTION
## Summary

- abort the internal agent producer when the stream consumer exits early
- propagate upstream abort signals through a local controller used by agent executor calls
- prevent invalid tool-call handling from leaving a background agent loop running

## Testing

- `yarn tsc --noEmit`
- `yarn fast-build`

## Notes

When `character_reply` tool input is invalid, the stream consumer can throw before the agent executor finishes. Without aborting the producer, the executor may continue planning in the background and repeatedly call the model even though the character pipeline has already left the stream.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling for streaming operations to ensure proper cleanup of resources when streams are interrupted or terminated, enhancing overall reliability and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->