### PR TITLE
chore(package): bump version to 0.0.225

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-character",
     "description": "Let the large language model play a role, disguise as a group friend",
-    "version": "0.0.224",
+    "version": "0.0.225",
     "type": "module",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",


### PR DESCRIPTION
## 摘要

- 将 `koishi-plugin-chatluna-character` 版本号从 `0.0.224` 升至 `0.0.225`

## 发布说明

- 合并到 `main` 后由 `Publish` 工作流发布 npm 新版本

## 校验

- 未运行构建，仅版本号变更
