### PR TITLE
fix: improve character tool retry handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "eslint-plugin-promise": "^7.2.1",
         "koishi": "^4.18.9",
         "koishi-plugin-adapter-onebot": "^6.8.0",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.2",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.3",
         "typescript": "^5.9.2",
         "yakumo": "^1.0.0",
         "yakumo-esbuild": "^1.0.0",
@@ -74,7 +74,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.2"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
     },
     "peerDependenciesMeta": {
         "@koishijs/plugin-console": {

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -1738,18 +1738,6 @@ async function* streamModelResponse(
             let messages = completionMessages
             if (idx > 0) {
                 const errText = String(err)
-                const lastAiIndex = completionMessages
-                    .map((message) => message.getType())
-                    .lastIndexOf('ai')
-                const retryBaseMessages =
-                    config.experimentalToolCallReply && config.toolCalling
-                        ? [completionMessages[0]].concat(
-                              completionMessages.slice(
-                                  Math.max(1, lastAiIndex + 1)
-                              )
-                          )
-                        : completionMessages
-
                 if (errText.includes('Failed to parse response')) {
                     const retryPrompt =
                         config.experimentalToolCallReply && config.toolCalling
@@ -1776,8 +1764,11 @@ Use the content from the previous reply and call \`character_reply\` now.`
 The parser error was: ${errText}.
 Reply again using valid XML output with <message> tags.`
                     const failedCalls = failedMessage
-                        ? (((failedMessage as unknown as { tool_calls?: ReplyToolCall[] })
-                              .tool_calls ?? []) as ReplyToolCall[])
+                        ? (((
+                              failedMessage as unknown as {
+                                  tool_calls?: ReplyToolCall[]
+                              }
+                          ).tool_calls ?? []) as ReplyToolCall[])
                         : []
                     const appendFailed =
                         failedMessage &&
@@ -1787,9 +1778,7 @@ Reply again using valid XML output with <message> tags.`
                                 (call) => call.name === 'character_reply'
                             ))
 
-                    messages = (
-                        appendFailed ? completionMessages : retryBaseMessages
-                    ).concat(
+                    messages = completionMessages.concat(
                         ...(appendFailed ? [failedMessage] : []),
                         new HumanMessage(
                             appendFailed

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -416,7 +416,7 @@ function createReplyTools(
         is_final: {
             type: 'boolean',
             description:
-                'Whether this is the final reply of the current turn. Use false only for temporary progress updates when you still need more tools or more reasoning. Use true for the final reply of this turn.'
+                'Whether this is the final reply of the current turn. Use false only for temporary progress updates, and only when you call the next non-character tool in the same assistant response. Never call character_reply with is_final=false as the only tool call. Use true for the final reply of this turn.'
         },
         messages: {
             type: 'array',
@@ -546,7 +546,7 @@ function createReplyTools(
                 {
                     name: 'character_reply',
                     description:
-                        'Send in-character reply messages. Use the literal string `\\n` for line breaks in all string fields. Do not use real newline characters. Do not wrap content in XML tags inside any field.',
+                        'Send in-character reply messages. Progress updates with is_final=false must be paired with the next non-character tool call in the same assistant response. Use the literal string `\\n` for line breaks in all string fields. Do not use real newline characters. Do not wrap content in XML tags inside any field.',
                     returnDirect: false,
                     verboseParsingErrors: true,
                     schema: {
@@ -765,7 +765,7 @@ function formatReplyUserPrompt(session: Session, config: RuntimeConfig) {
     if (config.experimentalToolCallReply && config.toolCalling) {
         tips.push(
             'All user-visible reply content must be sent through `character_reply`. Do not end the turn with plain text outside this tool.',
-            'Before calling time-consuming tools (such as searching), send a progress update to the user with `character_reply` first. Quick tools that finish almost instantly, such as reading a voice message, do not need this.'
+            'Before calling time-consuming tools (such as searching), send a progress update to the user with `character_reply` and call the time-consuming tool in the same assistant response. Never call `character_reply` with `is_final=false` alone. Quick tools that finish almost instantly, such as reading a voice message, do not need this.'
         )
 
         if (config.toolCallReplyStatusTag) {
@@ -1738,6 +1738,18 @@ async function* streamModelResponse(
             let messages = completionMessages
             if (idx > 0) {
                 const errText = String(err)
+                const lastAiIndex = completionMessages
+                    .map((message) => message.getType())
+                    .lastIndexOf('ai')
+                const retryBaseMessages =
+                    config.experimentalToolCallReply && config.toolCalling
+                        ? [completionMessages[0]].concat(
+                              completionMessages.slice(
+                                  Math.max(1, lastAiIndex + 1)
+                              )
+                          )
+                        : completionMessages
+
                 if (errText.includes('Failed to parse response')) {
                     const retryPrompt =
                         config.experimentalToolCallReply && config.toolCalling
@@ -1763,9 +1775,30 @@ Use the content from the previous reply and call \`character_reply\` now.`
                             : `Your previous reply used an invalid format and could not be delivered.
 The parser error was: ${errText}.
 Reply again using valid XML output with <message> tags.`
-                    messages = completionMessages.concat(
-                        ...(failedMessage ? [failedMessage] : []),
-                        new HumanMessage(retryPrompt)
+                    const failedCalls = failedMessage
+                        ? (((failedMessage as unknown as { tool_calls?: ReplyToolCall[] })
+                              .tool_calls ?? []) as ReplyToolCall[])
+                        : []
+                    const appendFailed =
+                        failedMessage &&
+                        (!config.experimentalToolCallReply ||
+                            !config.toolCalling ||
+                            failedCalls.every(
+                                (call) => call.name === 'character_reply'
+                            ))
+
+                    messages = (
+                        appendFailed ? completionMessages : retryBaseMessages
+                    ).concat(
+                        ...(appendFailed ? [failedMessage] : []),
+                        new HumanMessage(
+                            appendFailed
+                                ? retryPrompt
+                                : retryPrompt.replace(
+                                      /Use the content from the previous reply and call `character_reply` again\.|Use the content from the previous reply and send it through `character_reply` now\.|Use the content from the previous reply and call `character_reply` now\./,
+                                      'Retry the current turn from the original user request. Do not copy or summarize the failed reply.'
+                                  )
+                        )
                     )
                 }
             }
@@ -1819,7 +1852,7 @@ Reply again using valid XML output with <message> tags.`
             return
         } catch (e) {
             if (signal?.aborted) return
-            if (idx < 1) {
+            if (idx < 1 && String(e).includes('Failed to parse response')) {
                 err = e
                 logger.warn('model response failed, retry once', e)
                 continue

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -230,13 +230,12 @@ export async function createChatLunaChain(
             const mask =
                 toolMask ??
                 (await ctx.chatluna.resolveToolMask({
-                    session
-                    // source: 'character'
+                    session,
+                    source: 'character'
                 }))
 
             toolsRef.update(session, copyOfMessages, mask)
             extraRef.value = extraTools ? extraTools(session) : []
-
             return mask
         }
 
@@ -249,6 +248,7 @@ export async function createChatLunaChain(
                 ...input,
                 configurable: {
                     ...(input.configurable ?? {}),
+                    source: 'character',
                     ...(toolMask != null ? { toolMask } : {})
                 }
             }
@@ -305,6 +305,7 @@ export async function createChatLunaChain(
                 signal: ctl.signal,
                 configurable: {
                     ...(options?.configurable ?? {}),
+                    source: 'character',
                     ...(toolMask != null ? { toolMask } : {})
                 },
                 callbacks: [
@@ -412,6 +413,7 @@ export async function createChatLunaChain(
                     ...input,
                     configurable: {
                         ...(input.configurable ?? {}),
+                        source: 'character',
                         ...(toolMask != null ? { toolMask } : {})
                     }
                 }
@@ -420,6 +422,7 @@ export async function createChatLunaChain(
                     ...(options ?? {}),
                     configurable: {
                         ...(options?.configurable ?? {}),
+                        source: 'character',
                         ...(toolMask != null ? { toolMask } : {})
                     }
                 }


### PR DESCRIPTION
## Summary

- restore `source: 'character'` when resolving and invoking ChatLuna tools
- require non-final `character_reply` progress updates to be paired with the next non-character tool call
- limit character-level outer retry to response parsing failures
- avoid appending failed tool-call messages when retrying mixed tool-call parse failures
- raise the ChatLuna dependency lower bound to `^1.4.0-alpha.3`

## Verification

- `yarn tsc --noEmit`
- `yarn fast-build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated koishi-plugin-chatluna to v1.4.0-alpha.3.

* **Bug Fixes**
  * Enhanced error recovery and retry mechanisms in tool interaction workflows for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->