### PR TITLE
fix: 允许 wake_up_reply 空上下文触发

### DIFF
--- a/src/plugins/filter.ts
+++ b/src/plugins/filter.ts
@@ -507,11 +507,6 @@ async function processSchedulerTickForGuild(
     const now = Date.now()
     const triggeredWakeUpReply = findWakeUpTrigger(info, now)
 
-    if (triggeredWakeUpReply && (service.getMessages(key)?.length ?? 0) < 1) {
-        store.set(key, info)
-        return
-    }
-
     if (service.isMute(session)) {
         store.set(key, info)
         return

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -72,6 +72,14 @@ export async function formatMessage(
     historyPrompt: string,
     focusMessage?: Message
 ) {
+    if (messages.length < 1) {
+        return {
+            recentMessages: [],
+            lastMessage: '',
+            contextMessages: []
+        } as const
+    }
+
     const maxTokens = config.maxTokens - 300
     let currentTokens = 0
 
@@ -82,14 +90,6 @@ export async function formatMessage(
     const selectedMessages: Message[] = []
     let lastMessage: string | undefined
     let lastSelectedMessage: Message | undefined
-
-    if (messages.length < 1) {
-        return {
-            recentMessages: [],
-            lastMessage: '',
-            contextMessages: []
-        } as const
-    }
 
     if (focusMessage && messages.includes(focusMessage)) {
         const xmlFocusMessage = formatMessageString(

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -83,6 +83,14 @@ export async function formatMessage(
     let lastMessage: string | undefined
     let lastSelectedMessage: Message | undefined
 
+    if (messages.length < 1) {
+        return {
+            recentMessages: [],
+            lastMessage: '',
+            contextMessages: []
+        } as const
+    }
+
     if (focusMessage && messages.includes(focusMessage)) {
         const xmlFocusMessage = formatMessageString(
             focusMessage,


### PR DESCRIPTION
## 变更内容

- 允许 `wake_up_reply` 在会话消息缓存为空时继续触发。
- 让 `formatMessage()` 在空消息列表下返回空历史，避免计划任务空上下文触发时抛出 `lastMessage is undefined`。

## 验证

- `yarn tsc --noEmit`
- `yarn fast-build`
- 已同步到本地 Koishi 插件目录并重启 `koishi` 容器。
- 已校验 `lib/index.cjs` 同步前后 sha256 一致。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler reliability when processing certain triggered events so flows proceed correctly under edge conditions.
  * Enhanced message formatting to gracefully handle empty message arrays, preventing errors and ensuring consistent display of recent/last/context messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->