### PR TITLE
fix: 改进 clear 命令目标处理

### DIFF
--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -5,29 +5,45 @@ export function apply(ctx: Context, config: Config) {
     ctx.command('chatluna.character', '角色扮演相关命令')
 
     ctx.command(
-        'chatluna.character.clear [group]',
-        '清除当前会话或指定群组的聊天记录',
+        'chatluna.character.clear [target]',
+        '清除当前会话或指定群组、私聊的聊天记录',
         {
             authority: 3
         }
-    ).action(async ({ session }, group) => {
-        const isDirect = session.isDirect
-        const groupId = group ?? (isDirect ? session.userId : session.guildId)
+    ).action(async ({ session }, target) => {
+        const isDirect = target
+            ? target.startsWith('private:') || target.startsWith('p:')
+            : session.isDirect
+        const id = target
+            ? target.startsWith('private:')
+                ? target.slice('private:'.length)
+                : target.startsWith('p:')
+                  ? target.slice('p:'.length)
+                : target.startsWith('group:')
+                  ? target.slice('group:'.length)
+                  : target.startsWith('g:')
+                    ? target.slice('g:'.length)
+                  : target
+            : isDirect
+              ? session.userId
+              : session.guildId
 
-        const key = group
-            ? `group:${group}`
-            : `${isDirect ? 'private' : 'group'}:${groupId}`
-
-        if (!groupId && !isDirect) {
+        if (!id) {
             await session.send('请检查你是否提供了群组或私聊用户 ID')
             return
         }
 
+        const key = `${isDirect ? 'private' : 'group'}:${id}`
         const label = isDirect ? '私聊' : '群组'
+        const hasTrigger = ctx.chatluna_character_trigger.get(key) != null
+        const cleared = await ctx.chatluna_character.clear(key)
 
-        await session.send(`已清除${label} ${groupId} 的聊天记录`)
+        if (!cleared && !hasTrigger) {
+            await session.send(`未找到${label} ${id} 的聊天记录`)
+            return
+        }
 
-        await ctx.chatluna_character.clear(key)
         await ctx.chatluna_character_trigger.delete(key)
+        await session.send(`已清除${label} ${id} 的聊天记录`)
     })
 }

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -11,22 +11,13 @@ export function apply(ctx: Context, config: Config) {
             authority: 3
         }
     ).action(async ({ session }, target) => {
-        const isDirect = target
-            ? target.startsWith('private:') || target.startsWith('p:')
-            : session.isDirect
-        const id = target
-            ? target.startsWith('private:')
-                ? target.slice('private:'.length)
-                : target.startsWith('p:')
-                  ? target.slice('p:'.length)
-                : target.startsWith('group:')
-                  ? target.slice('group:'.length)
-                  : target.startsWith('g:')
-                    ? target.slice('g:'.length)
-                  : target
-            : isDirect
-              ? session.userId
-              : session.guildId
+        const matched = target?.match(/^(?:(private|p)|(group|g)):(.*)$/)
+        const isDirect = matched
+            ? matched[1] != null
+            : !target && session.isDirect
+        const id = matched
+            ? matched[3]
+            : target ?? (isDirect ? session.userId : session.guildId)
 
         if (!id) {
             await session.send('请检查你是否提供了群组或私聊用户 ID')
@@ -34,9 +25,15 @@ export function apply(ctx: Context, config: Config) {
         }
 
         const key = `${isDirect ? 'private' : 'group'}:${id}`
+        const currentKey = `${session.isDirect ? 'private' : 'group'}:${
+            session.isDirect ? session.userId : session.guildId
+        }`
         const label = isDirect ? '私聊' : '群组'
         const hasTrigger = ctx.chatluna_character_trigger.get(key) != null
-        const cleared = await ctx.chatluna_character.clear(key)
+        const cleared = await ctx.chatluna_character.clear(
+            key,
+            key === currentKey
+        )
 
         if (!cleared && !hasTrigger) {
             await session.send(`未找到${label} ${id} 的聊天记录`)

--- a/src/service/message.ts
+++ b/src/service/message.ts
@@ -462,24 +462,8 @@ export class MessageCollector extends Service {
             })
     }
 
-    async clear(groupId?: string) {
+    async clear(groupId?: string, force?: boolean) {
         if (groupId) {
-            const temp = this._groupTemp[groupId]
-            const hasRecord =
-                this._messages[groupId]?.length > 0 ||
-                temp?.completionMessages.length > 0 ||
-                temp?.status != null ||
-                temp?.statusMessageId != null ||
-                temp?.statusMessageUserId != null ||
-                this._groupLocks[groupId] != null ||
-                this._responseWaiters[groupId]?.length > 0 ||
-                this._pendingCooldownTriggers[groupId] != null ||
-                this._cooldownTriggerTimers[groupId] != null
-
-            if (!hasRecord) {
-                return false
-            }
-
             const isDirect = groupId.startsWith('private:')
             const id = isDirect
                 ? groupId.slice('private:'.length)
@@ -498,11 +482,30 @@ export class MessageCollector extends Service {
                 globalConfig,
                 guildConfig
             )
+            const temp = this._groupTemp[groupId]
+            const lock = this._groupLocks[groupId]
+            const hasRecord =
+                this._messages[groupId]?.length > 0 ||
+                temp?.completionMessages.length > 0 ||
+                temp?.status != null ||
+                temp?.statusMessageId != null ||
+                temp?.statusMessageUserId != null ||
+                lock?.responseLock ||
+                this._responseWaiters[groupId]?.length > 0 ||
+                this._pendingCooldownTriggers[groupId] != null ||
+                this._cooldownTriggerTimers[groupId] != null ||
+                (force && config.historyPull)
+
+            if (!hasRecord) {
+                return false
+            }
+
             const clearedAt = new Date()
             const unlock = await this._lockByGroupId(groupId)
             try {
                 this._messages[groupId] = []
                 this._groupTemp[groupId] = newTemp(clearedAt)
+                delete this._consumedPendingMessages[groupId]
 
                 delete this._pendingCooldownTriggers[groupId]
                 const timer = this._cooldownTriggerTimers[groupId]

--- a/src/service/message.ts
+++ b/src/service/message.ts
@@ -464,6 +464,22 @@ export class MessageCollector extends Service {
 
     async clear(groupId?: string) {
         if (groupId) {
+            const temp = this._groupTemp[groupId]
+            const hasRecord =
+                this._messages[groupId]?.length > 0 ||
+                temp?.completionMessages.length > 0 ||
+                temp?.status != null ||
+                temp?.statusMessageId != null ||
+                temp?.statusMessageUserId != null ||
+                this._groupLocks[groupId] != null ||
+                this._responseWaiters[groupId]?.length > 0 ||
+                this._pendingCooldownTriggers[groupId] != null ||
+                this._cooldownTriggerTimers[groupId] != null
+
+            if (!hasRecord) {
+                return false
+            }
+
             const isDirect = groupId.startsWith('private:')
             const id = isDirect
                 ? groupId.slice('private:'.length)
@@ -511,7 +527,7 @@ export class MessageCollector extends Service {
                 unlock()
             }
             this._emitClearChatHistory(groupId)
-            return
+            return true
         }
 
         // For clear-all, acquire locks in sorted order to prevent deadlocks
@@ -590,6 +606,7 @@ export class MessageCollector extends Service {
         for (const groupId of groupIds) {
             this._emitClearChatHistory(groupId)
         }
+        return groupIds.length > 0
     }
 
     async broadcastOnBot(


### PR DESCRIPTION
## 摘要

- 扩展 `chatluna.character.clear` 目标参数，支持 `private:`、`p:`、`group:`、`g:` 前缀。
- 裸 ID 继续按群聊处理，保持原有指定群组用法。
- 指定目标不存在可清理记录时返回“未找到”，避免无条件创建空清理记录并误报成功。

## 校验

- `yarn exec tsc --noEmit`
- `yarn fast-build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The character clearing command now supports flexible target specification for private and group contexts with improved error handling and feedback.

* **Improvements**
  * Message clearing operations now provide clearer success/failure status reporting to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->