### PR TITLE
chore(package): bump version to 0.0.227

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-character",
     "description": "Let the large language model play a role, disguise as a group friend",
-    "version": "0.0.226",
+    "version": "0.0.227",
     "type": "module",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",


### PR DESCRIPTION
## 摘要

- 将 `package.json` 版本号从 `0.0.226` 升级到 `0.0.227`。
- 用于触发合并到 `main` 后的 npm 发布流程。

## 校验

- 未运行，本次仅修改版本号。
