### PR TITLE
fix: 兼容数字类型回复引用

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -875,8 +875,9 @@ function buildXmlMessage(args: Record<string, unknown>) {
     }
 
     const quote =
-        typeof args.quote === 'string' && args.quote.length > 0
-            ? ` quote="${escape(args.quote, true)}"`
+        (typeof args.quote === 'string' || typeof args.quote === 'number') &&
+        String(args.quote).length > 0
+            ? ` quote="${escape(String(args.quote), true)}"`
             : ''
 
     if (Array.isArray(args.content)) {
@@ -2451,8 +2452,12 @@ function getReplyToolInputError(
         }
 
         const quote = (msg as Record<string, unknown>).quote
-        if (quote != null && typeof quote !== 'string') {
-            return `Field messages[${i}].quote must be a string`
+        if (
+            quote != null &&
+            typeof quote !== 'string' &&
+            typeof quote !== 'number'
+        ) {
+            return `Field messages[${i}].quote must be a string or number`
         }
 
         for (let j = 0; j < content.length; j++) {

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -291,8 +291,13 @@ function buildNextReplyToolTags(value: unknown) {
                         ? String(condition.user_id).trim()
                         : ''
                 if (userId) {
+                    const escapedUserId = userId
+                        .replaceAll('&', '&amp;')
+                        .replaceAll('<', '&lt;')
+                        .replaceAll('>', '&gt;')
+                        .replaceAll('"', '&quot;')
                     tags.push(
-                        `<next_reply group="${groupIdx}" type="message_from_user" user_id="${userId.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;')}" />`
+                        `<next_reply group="${groupIdx}" type="message_from_user" user_id="${escapedUserId}" />`
                     )
                 }
                 continue
@@ -886,9 +891,9 @@ function buildXmlMessage(args: Record<string, unknown>) {
     }
 
     const quote =
-        (typeof args.quote === 'string' || typeof args.quote === 'number') &&
-        String(args.quote).length > 0
-            ? ` quote="${escape(String(args.quote), true)}"`
+        typeof args.quote === 'number' ||
+        (typeof args.quote === 'string' && args.quote.length > 0)
+            ? ` quote="${escape(args.quote, true)}"`
             : ''
 
     if (Array.isArray(args.content)) {

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -195,25 +195,31 @@ function extractNextReplyReasonsFromTool(value: unknown) {
 
                 const condition = it as NextReplyToolCondition
                 if (condition.type === 'message_from_user') {
-                    if (
-                        typeof condition.user_id === 'string' &&
-                        condition.user_id.trim()
-                    ) {
-                        return `id_${condition.user_id.trim()}`
+                    const userId =
+                        typeof condition.user_id === 'string' ||
+                        typeof condition.user_id === 'number'
+                            ? String(condition.user_id).trim()
+                            : ''
+                    if (userId) {
+                        return `id_${userId}`
                     }
 
                     return undefined
                 }
 
                 if (condition.type === 'no_message_from_user') {
+                    const userId =
+                        typeof condition.user_id === 'string' ||
+                        typeof condition.user_id === 'number'
+                            ? String(condition.user_id).trim()
+                            : ''
                     if (
                         typeof condition.seconds === 'number' &&
                         Number.isFinite(condition.seconds) &&
                         condition.seconds > 0 &&
-                        typeof condition.user_id === 'string' &&
-                        condition.user_id.trim()
+                        userId
                     ) {
-                        if (condition.user_id.trim() === 'all') {
+                        if (userId === 'all') {
                             return `time_${condition.seconds}s`
                         }
 
@@ -222,10 +228,10 @@ function extractNextReplyReasonsFromTool(value: unknown) {
                             Number.isFinite(condition.max_wait_seconds) &&
                             condition.max_wait_seconds > 0
                         ) {
-                            return `time_${condition.seconds}s_id_${condition.user_id.trim()}_max_${condition.max_wait_seconds}s`
+                            return `time_${condition.seconds}s_id_${userId}_max_${condition.max_wait_seconds}s`
                         }
 
-                        return `time_${condition.seconds}s_id_${condition.user_id.trim()}`
+                        return `time_${condition.seconds}s_id_${userId}`
                     }
                 }
 
@@ -279,40 +285,45 @@ function buildNextReplyToolTags(value: unknown) {
 
             const condition = conditionItem as NextReplyToolCondition
             if (condition.type === 'message_from_user') {
-                if (
-                    typeof condition.user_id === 'string' &&
-                    condition.user_id.trim()
-                ) {
+                const userId =
+                    typeof condition.user_id === 'string' ||
+                    typeof condition.user_id === 'number'
+                        ? String(condition.user_id).trim()
+                        : ''
+                if (userId) {
                     tags.push(
-                        `<next_reply group="${groupIdx}" type="message_from_user" user_id="${condition.user_id.trim().replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;')}" />`
+                        `<next_reply group="${groupIdx}" type="message_from_user" user_id="${userId.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;')}" />`
                     )
                 }
                 continue
             }
 
             if (condition.type === 'no_message_from_user') {
+                const userId =
+                    typeof condition.user_id === 'string' ||
+                    typeof condition.user_id === 'number'
+                        ? String(condition.user_id).trim()
+                        : ''
                 if (
                     typeof condition.seconds === 'number' &&
                     Number.isFinite(condition.seconds) &&
                     condition.seconds > 0 &&
-                    typeof condition.user_id === 'string' &&
-                    condition.user_id.trim()
+                    userId
                 ) {
-                    const userId = condition.user_id
-                        .trim()
+                    const escapedUserId = userId
                         .replaceAll('&', '&amp;')
                         .replaceAll('<', '&lt;')
                         .replaceAll('>', '&gt;')
                         .replaceAll('"', '&quot;')
                     const maxWait =
-                        condition.user_id.trim() !== 'all' &&
+                        userId !== 'all' &&
                         typeof condition.max_wait_seconds === 'number' &&
                         Number.isFinite(condition.max_wait_seconds) &&
                         condition.max_wait_seconds > 0
                             ? ` max_wait_seconds="${condition.max_wait_seconds}"`
                             : ''
                     tags.push(
-                        `<next_reply group="${groupIdx}" type="no_message_from_user" user_id="${userId}" seconds="${condition.seconds}"${maxWait} />`
+                        `<next_reply group="${groupIdx}" type="no_message_from_user" user_id="${escapedUserId}" seconds="${condition.seconds}"${maxWait} />`
                     )
                 }
             }


### PR DESCRIPTION
## 说明

修复 `character_reply` 工具调用中 ID 类字段偶尔由模型输出为数字时处理不稳定的问题。

当前工具 schema 仍声明这些字段为字符串，避免多类型 schema 被模型 API 拒绝；运行时额外接受数字，并在使用前转换为字符串。

包含：

- `messages[].quote`
- `next_reply.conditions[].user_id`

## 验证

- `./node_modules/.bin/tsc --noEmit`
- `yarn fast-build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quote fields in chat interactions now accept both text and numeric values (numbers converted to text), so quotes are preserved and emitted consistently.

* **Bug Fixes**
  * Reply conditions now accept numeric or string user IDs, improving message-from-user / no-message-from-user tagging.
  * Quote validation tightened to reject unsupported types and provide clearer error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->