### PR TITLE
chore(package): bump version to 0.0.228

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-character",
     "description": "Let the large language model play a role, disguise as a group friend",
-    "version": "0.0.227",
+    "version": "0.0.228",
     "type": "module",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",


### PR DESCRIPTION
## 说明

将 `koishi-plugin-chatluna-character` 版本号从 `0.0.227` 提升到 `0.0.228`，用于触发合并到 `main` 后的 npm 发布流程。

## 版本确认

- npm 当前版本：`0.0.227`
- 目标版本：`0.0.228`
