### PR TITLE
fix: 统一 historyPull 触发入口

### DIFF
--- a/src/service/message.ts
+++ b/src/service/message.ts
@@ -777,7 +777,6 @@ export class MessageCollector extends Service {
                 unlock()
             }
 
-            await this.pullHistory(session, message)
             const triggered = await this.triggerCollect(
                 session,
                 triggerReason,
@@ -828,15 +827,17 @@ export class MessageCollector extends Service {
         signal?: AbortSignal
     ) {
         const groupId = `${session.isDirect ? 'private' : 'group'}:${session.isDirect ? session.userId : session.guildId}`
-        const focusMessage = message ?? this._messages[groupId]?.at(-1)
-        const acquired = await this.acquireResponseLock(
-            session,
-            focusMessage ?? {
+        const focusMessage =
+            message ??
+            this._messages[groupId]?.at(-1) ??
+            ({
                 content: '',
                 name: session.bot.user?.name ?? session.selfId,
                 id: session.bot.selfId ?? '0'
-            }
-        )
+            } satisfies Message)
+
+        await this.pullHistory(session, focusMessage)
+        const acquired = await this.acquireResponseLock(session, focusMessage)
 
         if (!acquired) {
             return false
@@ -1005,7 +1006,6 @@ export class MessageCollector extends Service {
             return
         }
 
-        await this.pullHistory(pending.session, pending.message)
         await this.triggerCollect(
             pending.session,
             pending.triggerReason,


### PR DESCRIPTION
## 变更说明

- 将 `historyPull` 统一移动到 `triggerCollect()` 入口执行。
- 移除普通触发和冷却触发路径中重复的 `pullHistory()` 调用。
- 修复 `enableFixedIntervalTrigger=true` 且 `messageInterval=0` 时，等待聚合触发路径不会拉取历史的问题。

## 验证

- `yarn tsc --noEmit`
- `yarn fast-build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message collection flow so conversation history is loaded more reliably before processing.
  * Fixed cases where triggering a collection could miss the most recent context when no message was provided.
  * Reduced duplicate history-loading steps, helping make message handling more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->