### PR TITLE
chore(package): bump version to 0.0.230

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-character",
     "description": "Let the large language model play a role, disguise as a group friend",
-    "version": "0.0.229",
+    "version": "0.0.230",
     "type": "module",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",


### PR DESCRIPTION
## 变更说明

- 将 `package.json` 版本号从 `0.0.229` 提升到 `0.0.230`。

## 发布依据

- npm 当前版本：`0.0.229`
- 目标版本：`0.0.230`

## 验证

- 未运行，版本号变更仅涉及 `package.json`。
