### PR TITLE
[Feature] 支持会话类型提示词变量

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -1539,6 +1539,9 @@ async function prepareMessages(
         preset: currentPreset.name,
         conversationId: session.isDirect ? session.userId : session.guildId
     }
+    const conversationType = session.isDirect
+        ? `你正在与用户 ${session.username}（${session.userId}）的私聊中`
+        : `你正在群聊 ${(await session.bot.getGuild(session.guildId)).name}（${session.guildId}）中`
 
     let historyNewMessages = recentMessages
     if (
@@ -1582,6 +1585,7 @@ async function prepareMessages(
                 status: temp.status ?? currentPreset.status ?? '',
                 trigger_reason: triggerReasonText,
                 prompt: session.content,
+                conversationType,
                 built
             },
             session.app.chatluna.promptRenderer,
@@ -1602,6 +1606,7 @@ async function prepareMessages(
             status: temp.status ?? currentPreset.status ?? '',
             trigger_reason: triggerReasonText,
             prompt: session.content,
+            conversationType,
             built
         },
         session.app.chatluna.promptRenderer,

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -1539,7 +1539,7 @@ async function prepareMessages(
         preset: currentPreset.name,
         conversationId: session.isDirect ? session.userId : session.guildId
     }
-    const conversationType = session.isDirect
+    const sessionType = session.isDirect
         ? `你正在与用户 ${session.username}（${session.userId}）的私聊中`
         : `你正在群聊 ${(await session.bot.getGuild(session.guildId)).name}（${session.guildId}）中`
 
@@ -1585,7 +1585,7 @@ async function prepareMessages(
                 status: temp.status ?? currentPreset.status ?? '',
                 trigger_reason: triggerReasonText,
                 prompt: session.content,
-                conversationType,
+                sessionType,
                 built
             },
             session.app.chatluna.promptRenderer,
@@ -1606,7 +1606,7 @@ async function prepareMessages(
             status: temp.status ?? currentPreset.status ?? '',
             trigger_reason: triggerReasonText,
             prompt: session.content,
-            conversationType,
+            sessionType,
             built
         },
         session.app.chatluna.promptRenderer,


### PR DESCRIPTION
## 变更内容

- 新增 `conversationType` 提示词变量。
- 私聊场景包含当前用户名和用户 ID。
- 群聊场景包含当前群聊名和群聊 ID。
- 同时向当前轮及持久化的 Input 提示词传入该变量。
- 不修改默认预设，用户可在预设文件的 `input` 部分通过 `{conversationType}` 手动引用。

## 验证
本地实际测试可正常获取用户名和用户 ID、群聊名和群聊 ID并以变量形式传入

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Chat prompts now include the conversation type, distinguishing between private chats and group conversations.
  * For group chats, prompts now incorporate the associated group name to provide better context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->