### PR TITLE
fix(agent): 修复新版 ChatLuna 将虚拟会话构造改为异步后导致的 TypeScript 构建错误

### DIFF
--- a/src/plugins/agent.ts
+++ b/src/plugins/agent.ts
@@ -21,7 +21,7 @@ export function apply(ctx: Context) {
             live?.bot?.status === Universal.Status.ONLINE
                 ? live
                 : routing && bot?.status === Universal.Status.ONLINE
-                  ? buildVirtualSession(
+                  ? await buildVirtualSession(
                         bot,
                         { ...routing, username: 'task' },
                         { message: '', messageName: 'task' }


### PR DESCRIPTION
## 问题

新版 `koishi-plugin-chatluna` 将 `buildVirtualSession()` 调整为异步函数，返回类型由 `Session` 变为 `Promise<Session>`。

当前子代理任务唤醒流程未等待该异步调用完成，导致 `session` 被推导为：

```ts
Session | Promise<Session> | undefined
```

在将其传入 setLastSession() 和 triggerMessage() 时触发 TypeScript 类型错误，导致 Publish 工作流的构建阶段失败。

## 变更内容
等待 buildVirtualSession() 返回实际的 Session。

## 兼容性
await 同时支持同步返回值和 Promise，因此该修改兼容旧版与新版 ChatLuna 接口。


## 本地复现方式

普通 `yarn fast-build` 最初没有复现，是因为本地存在 `tsconfig.tsbuildinfo` 增量缓存，同时本地 ChatLuna 的旧声明文件曾将 `buildVirtualSession()` 标记为同步返回。

确认本地声明已经变为 `Promise<Session>` 后，在修复前执行：

```powershell
yarn tsc --build tsconfig.json --force
```

该命令强制重新执行 fast-build 中的 TypeScript 构建阶段，随后复现了与 GitHub Actions 完全相同的第 41、56 行 TS2345 错误。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automatic agent task wake-ups by ensuring sessions are fully initialized before messages are dispatched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->