### PR TITLE
fix(filter): improve force mute keyword triggers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -141,7 +141,7 @@ const groupChatBehaviorConfig = Schema.object({
 const commonMuteConfig = Schema.object({
     isForceMute: Schema.boolean()
         .description(
-            '是否启用关键词触发闭嘴（当收到包含关键词的消息时会沉默，一段时间内无法被任何方式触发，关键词需要在预设文件里配置）'
+            '是否启用关键词触发闭嘴（关键词在预设 mute_keyword 配置；私聊含关键词即可；群聊需 @/引用 或消息含角色昵称，且含关键词；沉默期间无法被任何方式触发）'
         )
         .default(false),
     muteTime: Schema.number()

--- a/src/plugins/filter.ts
+++ b/src/plugins/filter.ts
@@ -593,13 +593,23 @@ export async function apply(ctx: Context, config: Config) {
     const preset = service.preset
     const logger = service.logger
 
-    const globalPrivatePreset = await preset.getPreset(
+    let globalPrivatePreset = await preset.getPreset(
         config.globalPrivateConfig.preset
     )
-    const globalGroupPreset = await preset.getPreset(
+    let globalGroupPreset = await preset.getPreset(
         config.globalGroupConfig.preset
     )
-    const presetPool: Record<string, PresetTemplate> = {}
+    let presetPool: Record<string, PresetTemplate> = {}
+
+    ctx.on('chatluna_character/preset_updated', () => {
+        globalPrivatePreset = preset.getPresetForCache(
+            config.globalPrivateConfig.preset
+        )
+        globalGroupPreset = preset.getPresetForCache(
+            config.globalGroupConfig.preset
+        )
+        presetPool = {}
+    })
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ctx.on('guild-member' as any, (session: Session) => {
@@ -771,12 +781,12 @@ export async function apply(ctx: Context, config: Config) {
         }
 
         const muteKeywords = currentPreset.mute_keyword ?? []
-        const forceMuteActive =
-            copyOfConfig.isForceMute && isAppel && muteKeywords.length > 0
+        const forceMuteEnabled =
+            copyOfConfig.isForceMute && muteKeywords.length > 0
         const needPlainText =
             copyOfConfig.isNickname ||
             copyOfConfig.isNickNameWithContent ||
-            forceMuteActive
+            forceMuteEnabled
 
         const plainTextContent = needPlainText
             ? (session.elements ?? [])
@@ -785,12 +795,17 @@ export async function apply(ctx: Context, config: Config) {
                   .join('')
             : ''
 
-        if (forceMuteActive) {
-            const needMute = muteKeywords.some((value) =>
+        if (forceMuteEnabled) {
+            const hasMuteKeyword = muteKeywords.some((value) =>
                 plainTextContent.includes(value)
             )
+            const hasNickName = currentPreset.nick_name.some((value) =>
+                plainTextContent.includes(value)
+            )
+            const canMute =
+                hasMuteKeyword && (session.isDirect || isAppel || hasNickName)
 
-            if (needMute) {
+            if (canMute) {
                 logger.debug(`mute content: ${message.content}`)
                 service.mute(session, copyOfConfig.muteTime * 1000)
             }

--- a/src/service/message.ts
+++ b/src/service/message.ts
@@ -204,6 +204,10 @@ export class MessageCollector extends Service {
         const key = `${session.isDirect ? 'private' : 'group'}:${session.isDirect ? session.userId : session.guildId}`
         await this._addMessage(session, msg, { silent: true })
 
+        if (this.isMute(session)) {
+            return false
+        }
+
         const active = this._activePendingMessages[key]
         if (active) {
             active.append(msg, reason)
@@ -826,6 +830,10 @@ export class MessageCollector extends Service {
         message?: Message,
         signal?: AbortSignal
     ) {
+        if (this.isMute(session)) {
+            return false
+        }
+
         const groupId = `${session.isDirect ? 'private' : 'group'}:${session.isDirect ? session.userId : session.guildId}`
         const focusMessage =
             message ??


### PR DESCRIPTION
## Summary
- 群聊：`@/引用` + 关键词，或消息含角色昵称 + 关键词时触发闭嘴（**仅关键词不触发**）
- 私聊：含关键词即可触发闭嘴
- `filter` 监听 `preset_updated`，刷新预设缓存，避免改 `mute_keyword` 不生效
- `triggerMessage` / `triggerCollect` 在 mute 期间直接返回，避免 agent 等旁路唤醒
- 更新配置项说明文案，与实际行为一致

## Test plan
- [ ] 开启 `isForceMute`，预设配置 `mute_keyword`
- [ ] 群聊仅发关键词 → 不闭嘴
- [ ] 群聊 `@机器人 关键词` → 闭嘴，muteTime 内 @/昵称/活跃度均不回复
- [ ] 群聊 `昵称 关键词` → 闭嘴
- [ ] 私聊发关键词 → 闭嘴
- [ ] 修改预设 `mute_keyword` 后无需重启即可生效
- [ ] mute 期间 agent task 完成不会唤醒角色

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced keyword-based mute detection across direct messages, mentions, and messages containing configured nicknames.
  * Preset updates are now reflected without requiring a restart.

* **Bug Fixes**
  * Muted sessions no longer trigger message collection, response handling, or chat history retrieval.

* **Documentation**
  * Clarified configuration guidance for forced mute behavior in private and group chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->