### PR TITLE
fix(filter): improve force mute keyword triggers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -141,7 +141,7 @@ const groupChatBehaviorConfig = Schema.object({
 const commonMuteConfig = Schema.object({
     isForceMute: Schema.boolean()
         .description(
-            '是否启用关键词触发闭嘴（当收到包含关键词的消息时会沉默，一段时间内无法被任何方式触发，关键词需要在预设文件里配置）'
+            '是否启用关键词闭嘴。私聊消息包含预设中的 mute_keyword 即可触发；群聊消息还需 @/引用角色，或包含角色昵称。闭嘴期间角色不会被任何方式触发。'
         )
         .default(false),
     muteTime: Schema.number()

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -120,6 +120,7 @@ class PendingMessageQueue extends MessageQueue {
     private _messages: {
         message: Message
         triggerReason?: string
+        seq: number
     }[] = []
 
     constructor(
@@ -129,8 +130,8 @@ class PendingMessageQueue extends MessageQueue {
         super()
     }
 
-    pushRaw(message: Message, triggerReason?: string) {
-        this._messages.push({ message, triggerReason })
+    pushRaw(message: Message, triggerReason: string | undefined, seq: number) {
+        this._messages.push({ message, triggerReason, seq })
         return true
     }
 
@@ -164,15 +165,16 @@ class PendingMessageQueue extends MessageQueue {
     }
 
     takeLatestTrigger() {
-        for (let i = this._messages.length - 1; i >= 0; i--) {
-            const entry = this._messages[i]
-            if (!entry.triggerReason) {
-                continue
+        let latest: (typeof this._messages)[number] | undefined
+        for (const entry of this._messages) {
+            if (entry.triggerReason && (!latest || entry.seq > latest.seq)) {
+                latest = entry
             }
-
-            this._messages = []
-            return entry
         }
+        if (latest) {
+            this._messages = []
+        }
+        return latest
     }
 }
 
@@ -2130,8 +2132,8 @@ export async function apply(ctx: Context, config: Config) {
                 }
             )
 
-            service.startPendingMessages(session, (message, reason) => {
-                queue?.pushRaw(message, reason)
+            service.startPendingMessages(session, (message, reason, seq) => {
+                queue?.pushRaw(message, reason, seq)
             })
 
             try {
@@ -2297,7 +2299,10 @@ export async function apply(ctx: Context, config: Config) {
                 await service.triggerCollect(
                     session,
                     pending.triggerReason!,
-                    pending.message
+                    pending.message,
+                    undefined,
+                    true,
+                    pending.seq
                 )
             }
         }

--- a/src/plugins/filter.ts
+++ b/src/plugins/filter.ts
@@ -744,10 +744,12 @@ export async function apply(ctx: Context, config: Config) {
             forceMuteEnabled
 
         const plainTextContent = needPlainText
-            ? (session.elements ?? [])
-                  .filter((element) => element.type === 'text')
-                  .map((element) => element.attrs?.content ?? '')
-                  .join('')
+            ? session.elements
+                ? session.elements
+                      .filter((element) => element.type === 'text')
+                      .map((element) => element.attrs?.content ?? '')
+                      .join('')
+                : session.content
             : ''
 
         if (forceMuteEnabled) {

--- a/src/plugins/filter.ts
+++ b/src/plugins/filter.ts
@@ -593,13 +593,23 @@ export async function apply(ctx: Context, config: Config) {
     const preset = service.preset
     const logger = service.logger
 
-    const globalPrivatePreset = await preset.getPreset(
+    let globalPrivatePreset = await preset.getPreset(
         config.globalPrivateConfig.preset
     )
-    const globalGroupPreset = await preset.getPreset(
+    let globalGroupPreset = await preset.getPreset(
         config.globalGroupConfig.preset
     )
-    const presetPool: Record<string, PresetTemplate> = {}
+    let presetPool: Record<string, PresetTemplate> = {}
+
+    ctx.on('chatluna_character/preset_updated', () => {
+        globalPrivatePreset = preset.getPresetForCache(
+            config.globalPrivateConfig.preset
+        )
+        globalGroupPreset = preset.getPresetForCache(
+            config.globalGroupConfig.preset
+        )
+        presetPool = {}
+    })
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ctx.on('guild-member' as any, (session: Session) => {
@@ -771,12 +781,12 @@ export async function apply(ctx: Context, config: Config) {
         }
 
         const muteKeywords = currentPreset.mute_keyword ?? []
-        const forceMuteActive =
-            copyOfConfig.isForceMute && isAppel && muteKeywords.length > 0
+        const forceMuteEnabled =
+            copyOfConfig.isForceMute && muteKeywords.length > 0
         const needPlainText =
             copyOfConfig.isNickname ||
             copyOfConfig.isNickNameWithContent ||
-            forceMuteActive
+            forceMuteEnabled
 
         const plainTextContent = needPlainText
             ? (session.elements ?? [])
@@ -785,12 +795,17 @@ export async function apply(ctx: Context, config: Config) {
                   .join('')
             : ''
 
-        if (forceMuteActive) {
-            const needMute = muteKeywords.some((value) =>
+        if (forceMuteEnabled) {
+            const hasMuteKeyword = muteKeywords.some((value) =>
                 plainTextContent.includes(value)
             )
+            const hasNickName = currentPreset.nick_name.some((value) =>
+                plainTextContent.includes(value)
+            )
+            const canMute =
+                hasMuteKeyword && (session.isDirect || isAppel || hasNickName)
 
-            if (needMute) {
+            if (canMute) {
                 logger.debug(`mute content: ${message.content}`)
                 service.mute(session, copyOfConfig.muteTime * 1000)
             }

--- a/src/plugins/filter.ts
+++ b/src/plugins/filter.ts
@@ -489,7 +489,14 @@ async function processSchedulerTickForGuild(
     const triggerCollectStartedAt = Date.now()
     let triggered = false
     try {
-        triggered = await service.triggerCollect(session, triggerReason)
+        // The scheduler retries cooldown races itself and needs completion time.
+        triggered = await service.triggerCollect(
+            session,
+            triggerReason,
+            undefined,
+            undefined,
+            false
+        )
     } catch (e) {
         logger.error(`triggerCollect failed for session ${key}`, e)
         store.set(key, info)
@@ -759,7 +766,7 @@ export async function apply(ctx: Context, config: Config) {
             }
         }
 
-        const isMute = service.isMute(session)
+        const isMute = service.isForceMute(session)
 
         const isDirectTrigger =
             isAppel ||

--- a/src/service/message.ts
+++ b/src/service/message.ts
@@ -59,13 +59,19 @@ export class MessageCollector extends Service {
     private _pendingCooldownTriggers: Record<string, PendingCooldownTrigger> =
         {}
 
+    private _triggerSeq = 0
+
     private _replyToolFields: CharacterReplyToolField[] = []
 
     private _activePendingMessages: Record<
         string,
         {
             willConsume: boolean
-            append: (message: Message, triggerReason?: string) => void
+            append: (
+                message: Message,
+                triggerReason: string | undefined,
+                seq: number
+            ) => void
         }
     > = {}
 
@@ -134,12 +140,22 @@ export class MessageCollector extends Service {
 
     startPendingMessages(
         session: Session,
-        append: (message: Message, triggerReason?: string) => void
+        append: (
+            message: Message,
+            triggerReason: string | undefined,
+            seq: number
+        ) => void
     ) {
         const key = `${session.isDirect ? 'private' : 'group'}:${session.isDirect ? session.userId : session.guildId}`
         this._activePendingMessages[key] = {
             willConsume: false,
-            append
+            append: (message, triggerReason, seq) => {
+                if (triggerReason) {
+                    const lock = this._getGroupLocks(key)
+                    lock.triggerSeq = Math.max(lock.triggerSeq, seq)
+                }
+                append(message, triggerReason, seq)
+            }
         }
     }
 
@@ -159,9 +175,8 @@ export class MessageCollector extends Service {
     }
 
     mute(session: Session, time: number) {
-        const lock = this._getGroupLocks(
-            `${session.isDirect ? 'private' : 'group'}:${session.isDirect ? session.userId : session.guildId}`
-        )
+        const key = `${session.isDirect ? 'private' : 'group'}:${session.isDirect ? session.userId : session.guildId}`
+        const lock = this._getGroupLocks(key)
         let mute = lock.mute ?? 0
 
         if (time === 0) {
@@ -172,6 +187,11 @@ export class MessageCollector extends Service {
             mute = mute + time
         }
         lock.mute = mute
+        if (mute > Date.now()) {
+            delete this._pendingCooldownTriggers[key]
+            clearTimeout(this._cooldownTriggerTimers[key])
+            delete this._cooldownTriggerTimers[key]
+        }
     }
 
     async muteAtLeast(session: Session, time: number) {
@@ -179,7 +199,7 @@ export class MessageCollector extends Service {
         const unlock = await this._lockByGroupId(key)
         try {
             const groupLock = this._getGroupLocks(key)
-            groupLock.mute = Math.max(groupLock.mute ?? 0, Date.now() + time)
+            groupLock.cooldown = Math.max(groupLock.cooldown, Date.now() + time)
         } finally {
             unlock()
         }
@@ -201,23 +221,39 @@ export class MessageCollector extends Service {
     }
 
     async triggerMessage(session: Session, msg: Message, reason: string) {
+        const seq = ++this._triggerSeq
         const key = `${session.isDirect ? 'private' : 'group'}:${session.isDirect ? session.userId : session.guildId}`
         await this._addMessage(session, msg, { silent: true })
 
-        if (this.isMute(session)) {
+        if (this.isForceMute(session)) {
             return false
         }
 
         const active = this._activePendingMessages[key]
         if (active) {
-            active.append(msg, reason)
+            active.append(msg, reason, seq)
             return true
         }
 
-        return await this.triggerCollect(session, reason, msg)
+        return await this.triggerCollect(
+            session,
+            reason,
+            msg,
+            undefined,
+            true,
+            seq
+        )
     }
 
     isMute(session: Session) {
+        const lock = this._getGroupLocks(
+            `${session.isDirect ? 'private' : 'group'}:${session.isDirect ? session.userId : session.guildId}`
+        )
+
+        return Math.max(lock.mute, lock.cooldown) > Date.now()
+    }
+
+    isForceMute(session: Session) {
         const lock = this._getGroupLocks(
             `${session.isDirect ? 'private' : 'group'}:${session.isDirect ? session.userId : session.guildId}`
         )
@@ -441,6 +477,8 @@ export class MessageCollector extends Service {
         if (!this._groupLocks[groupId]) {
             this._groupLocks[groupId] = {
                 mute: 0,
+                cooldown: 0,
+                triggerSeq: 0,
                 responseLock: false
             }
         }
@@ -653,6 +691,7 @@ export class MessageCollector extends Service {
     }
 
     async broadcast(session: Session) {
+        const seq = ++this._triggerSeq
         const groupId = `${session.isDirect ? 'private' : 'group'}:${session.isDirect ? session.userId : session.guildId}`
         this.ctx.chatluna_character_trigger.setLastSession(session)
         const guildConfig = session.isDirect
@@ -761,80 +800,53 @@ export class MessageCollector extends Service {
             processImages: config
         })
 
-        const active = this._activePendingMessages[groupId]
-        if (active) {
-            active.append(message, triggerReason)
+        if (this.isForceMute(session)) {
             return true
         }
 
-        if (triggerReason && !this.isMute(session)) {
-            const unlock = await this._lockByGroupId(groupId)
-            try {
-                delete this._pendingCooldownTriggers[groupId]
-
-                const timer = this._cooldownTriggerTimers[groupId]
-                if (timer) {
-                    clearTimeout(timer)
-                    delete this._cooldownTriggerTimers[groupId]
-                }
-            } finally {
-                unlock()
-            }
-
-            const triggered = await this.triggerCollect(
-                session,
-                triggerReason,
-                message
-            )
-            return triggered
+        const active = this._activePendingMessages[groupId]
+        if (active) {
+            active.append(message, triggerReason, seq)
+            return true
         }
 
         if (triggerReason) {
-            const unlock = await this._lockByGroupId(groupId)
-
-            try {
-                this._pendingCooldownTriggers[groupId] = {
-                    session,
-                    triggerReason,
-                    message
-                }
-
-                const lock = this._getGroupLocks(groupId)
-                const delay = Math.max(lock.mute - Date.now(), 0)
-                const timer = this._cooldownTriggerTimers[groupId]
-                if (timer) {
-                    clearTimeout(timer)
-                }
-
-                this._cooldownTriggerTimers[groupId] = setTimeout(
-                    () => {
-                        this._flushCooldownTrigger(groupId).catch((err) => {
-                            this.logger.error(err)
-                        })
-                    },
-                    Math.min(delay, MAX_TIMEOUT_MS)
-                )
-            } finally {
-                unlock()
-            }
-
-            return true
+            return await this.triggerCollect(
+                session,
+                triggerReason,
+                message,
+                undefined,
+                true,
+                seq
+            )
         }
 
         return this.isMute(session)
     }
 
+    // True means executed or queued; defer=false only reports execution.
     async triggerCollect(
         session: Session,
         triggerReason: string,
         message?: Message,
-        signal?: AbortSignal
+        signal?: AbortSignal,
+        defer = true,
+        seq = ++this._triggerSeq
     ) {
-        if (this.isMute(session)) {
+        if (this.isForceMute(session) || signal?.aborted) {
             return false
         }
 
         const groupId = `${session.isDirect ? 'private' : 'group'}:${session.isDirect ? session.userId : session.guildId}`
+        const lock = this._getGroupLocks(groupId)
+        if (seq < lock.triggerSeq) {
+            return false
+        }
+        // Keep arrival order across queue replay, history pulls and lock waits.
+        // Scheduler retries must not supersede queued work without executing.
+        if (defer) {
+            lock.triggerSeq = seq
+        }
         const focusMessage =
             message ??
             this._messages[groupId]?.at(-1) ??
@@ -844,9 +856,38 @@ export class MessageCollector extends Service {
                 id: session.bot.selfId ?? '0'
             } satisfies Message)
 
-        await this.pullHistory(session, focusMessage)
         if (this.isMute(session)) {
+            return (
+                defer &&
+                this._queueCooldownTrigger({
+                    session,
+                    triggerReason,
+                    message: focusMessage,
+                    signal,
+                    seq
+                })
+            )
+        }
+
+        await this.pullHistory(session, focusMessage)
+        if (
+            this.isForceMute(session) ||
+            signal?.aborted ||
+            seq < lock.triggerSeq
+        ) {
             return false
+        }
+        if (this.isMute(session)) {
+            return (
+                defer &&
+                this._queueCooldownTrigger({
+                    session,
+                    triggerReason,
+                    message: focusMessage,
+                    signal,
+                    seq
+                })
+            )
         }
 
         const acquired = await this.acquireResponseLock(session, focusMessage)
@@ -855,10 +896,32 @@ export class MessageCollector extends Service {
             return false
         }
 
-        if (this.isMute(session)) {
+        if (
+            this.isForceMute(session) ||
+            signal?.aborted ||
+            seq < lock.triggerSeq
+        ) {
             await this.releaseResponseLock(session)
             return false
         }
+        if (this.isMute(session)) {
+            await this.releaseResponseLock(session)
+            return (
+                defer &&
+                this._queueCooldownTrigger({
+                    session,
+                    triggerReason,
+                    message: focusMessage,
+                    signal,
+                    seq
+                })
+            )
+        }
+
+        lock.triggerSeq = seq
+        delete this._pendingCooldownTriggers[groupId]
+        clearTimeout(this._cooldownTriggerTimers[groupId])
+        delete this._cooldownTriggerTimers[groupId]
 
         await this.ctx.parallel(
             'chatluna_character/message_collect',
@@ -988,6 +1051,27 @@ export class MessageCollector extends Service {
         }
     }
 
+    private _queueCooldownTrigger(pending: PendingCooldownTrigger) {
+        if (this.isForceMute(pending.session) || pending.signal?.aborted) {
+            return false
+        }
+
+        const session = pending.session
+        const key = `${session.isDirect ? 'private' : 'group'}:${session.isDirect ? session.userId : session.guildId}`
+        if (pending.seq < this._getGroupLocks(key).triggerSeq) {
+            return false
+        }
+        this._pendingCooldownTriggers[key] = pending
+        clearTimeout(this._cooldownTriggerTimers[key])
+        const delay = Math.max(this._getGroupLocks(key).cooldown - Date.now(), 0)
+        this._cooldownTriggerTimers[key] = setTimeout(() => {
+            this._flushCooldownTrigger(key).catch((err) => {
+                this.logger.error(err)
+            })
+        }, Math.min(delay, MAX_TIMEOUT_MS))
+        return true
+    }
+
     private async _flushCooldownTrigger(groupId: string) {
         const unlock = await this._lockByGroupId(groupId)
 
@@ -1000,8 +1084,13 @@ export class MessageCollector extends Service {
             }
 
             const lock = this._getGroupLocks(groupId)
-            if (lock.mute > Date.now()) {
-                const delay = Math.max(lock.mute - Date.now(), 0)
+            if (lock.mute > Date.now() || pending.signal?.aborted) {
+                delete this._pendingCooldownTriggers[groupId]
+                delete this._cooldownTriggerTimers[groupId]
+                return
+            }
+            if (lock.cooldown > Date.now()) {
+                const delay = Math.max(lock.cooldown - Date.now(), 0)
                 this._cooldownTriggerTimers[groupId] = setTimeout(
                     () => {
                         this._flushCooldownTrigger(groupId).catch((err) => {
@@ -1026,7 +1115,10 @@ export class MessageCollector extends Service {
         await this.triggerCollect(
             pending.session,
             pending.triggerReason,
-            pending.message
+            pending.message,
+            pending.signal,
+            true,
+            pending.seq
         )
     }
 

--- a/src/service/message.ts
+++ b/src/service/message.ts
@@ -1063,12 +1063,18 @@ export class MessageCollector extends Service {
         }
         this._pendingCooldownTriggers[key] = pending
         clearTimeout(this._cooldownTriggerTimers[key])
-        const delay = Math.max(this._getGroupLocks(key).cooldown - Date.now(), 0)
-        this._cooldownTriggerTimers[key] = setTimeout(() => {
-            this._flushCooldownTrigger(key).catch((err) => {
-                this.logger.error(err)
-            })
-        }, Math.min(delay, MAX_TIMEOUT_MS))
+        const delay = Math.max(
+            this._getGroupLocks(key).cooldown - Date.now(),
+            0
+        )
+        this._cooldownTriggerTimers[key] = setTimeout(
+            () => {
+                this._flushCooldownTrigger(key).catch((err) => {
+                    this.logger.error(err)
+                })
+            },
+            Math.min(delay, MAX_TIMEOUT_MS)
+        )
         return true
     }
 

--- a/src/service/message.ts
+++ b/src/service/message.ts
@@ -204,6 +204,10 @@ export class MessageCollector extends Service {
         const key = `${session.isDirect ? 'private' : 'group'}:${session.isDirect ? session.userId : session.guildId}`
         await this._addMessage(session, msg, { silent: true })
 
+        if (this.isMute(session)) {
+            return false
+        }
+
         const active = this._activePendingMessages[key]
         if (active) {
             active.append(msg, reason)
@@ -826,6 +830,10 @@ export class MessageCollector extends Service {
         message?: Message,
         signal?: AbortSignal
     ) {
+        if (this.isMute(session)) {
+            return false
+        }
+
         const groupId = `${session.isDirect ? 'private' : 'group'}:${session.isDirect ? session.userId : session.guildId}`
         const focusMessage =
             message ??
@@ -837,9 +845,18 @@ export class MessageCollector extends Service {
             } satisfies Message)
 
         await this.pullHistory(session, focusMessage)
+        if (this.isMute(session)) {
+            return false
+        }
+
         const acquired = await this.acquireResponseLock(session, focusMessage)
 
         if (!acquired) {
+            return false
+        }
+
+        if (this.isMute(session)) {
+            await this.releaseResponseLock(session)
             return false
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -321,6 +321,8 @@ export type MessageCollectorFilter = (
 
 export interface GroupLock {
     mute: number
+    cooldown: number
+    triggerSeq: number
     responseLock: boolean
 }
 
@@ -336,6 +338,8 @@ export type PendingCooldownTrigger = {
     session: Session
     triggerReason: string
     message: Message
+    signal?: AbortSignal
+    seq: number
 }
 
 export const IMAGE_SIZE_CACHE_LIMIT = 512


### PR DESCRIPTION
## Summary
- 私聊消息包含预设 `mute_keyword` 时触发闭嘴
- 群聊消息需同时包含 `mute_keyword`，并且 @/引用角色或包含角色昵称
- 监听 `preset_updated` 刷新 filter 预设缓存
- mute 期间阻止 `triggerMessage` / `triggerCollect` 等旁路唤醒
- 在历史拉取和响应锁等待后重新检查 mute；已取得锁时会先释放再返回
- 优化 `isForceMute` 配置说明

## Review follow-up
This supersedes #118 and addresses its review comments:
- clarify the force-mute configuration description
- close the mute race window around `pullHistory()` and `acquireResponseLock()`

## Validation
- [x] `tsc --noEmit`
- [x] ESLint for `src/plugins/filter.ts` and `src/service/message.ts`
- [x] `git diff --check`

## Manual test plan
- [x] 群聊仅发送关键词：不闭嘴
- [x] 群聊 `@机器人 + 关键词`：进入闭嘴状态
- [x] 群聊 `角色昵称 + 关键词`：进入闭嘴状态
- [x] 私聊发送关键词：进入闭嘴状态
- [x] 修改预设 `mute_keyword` 后无需重启即可生效
- [x] mute 期间 agent task 完成不会唤醒角色

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved forced-mute keyword handling for private messages, group messages, direct mentions, and configured nicknames.
  - Improved mute and cooldown handling during message collection and processing.
  - Prevented stale or superseded triggers from causing unintended responses.
  - Preset updates now take effect more reliably without requiring a restart.

- **Documentation**
  - Clarified the requirements for using the `mute_keyword` preset keyword in private and group messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->