### PR TITLE
fix: 完善 next_reply 条件校验

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -244,7 +244,7 @@ function extractNextReplyReasonsFromTool(value: unknown) {
         }
     }
 
-    return reasons
+    return reasons.length > 0 ? [reasons.join('|')] : []
 }
 
 function buildNextReplyToolTags(value: unknown) {
@@ -459,6 +459,7 @@ function createReplyTools(
                 properties: {
                     conditions: {
                         type: 'array',
+                        minItems: 1,
                         description:
                             'Conditions inside the same group. All of them must be satisfied together as AND.',
                         items: {
@@ -475,21 +476,27 @@ function createReplyTools(
                                 },
                                 seconds: {
                                     type: 'number',
+                                    minimum: 1,
+                                    multipleOf: 1,
                                     description:
                                         'Waiting time in seconds. Required for no_message_from_user. When user_id is all, counting starts immediately. Otherwise, counting starts only after the target user sends the first new message.'
                                 },
                                 user_id: {
                                     type: 'string',
+                                    minLength: 1,
+                                    pattern: '^[\\w-]+$',
                                     description:
                                         'Platform user ID of the target user. Required for message_from_user and no_message_from_user. Use all to mean any user.'
                                 },
                                 max_wait_seconds: {
                                     type: 'number',
+                                    minimum: 1,
+                                    multipleOf: 1,
                                     description:
                                         'Maximum total waiting time in seconds. Optional only for no_message_from_user when user_id is not all. Counting starts after the current turn finishes and this next_reply is registered, and the trigger fires when the limit is reached even if the user never sends the first message.'
                                 }
                             },
-                            required: ['type']
+                            required: ['type', 'user_id']
                         }
                     }
                 },
@@ -2582,6 +2589,60 @@ function getReplyToolInputError(
 
     if (config.toolCallReplyThinkTag && typeof args.think !== 'string') {
         return 'Field think must be a string'
+    }
+
+    if (
+        config.toolCallReplyNextReply &&
+        (!config.enableFixedIntervalTrigger || config.messageInterval !== 0) &&
+        Array.isArray(args.next_reply)
+    ) {
+        for (const [i, group] of args.next_reply.entries()) {
+            if (group.conditions.length < 1) {
+                return `Field next_reply[${i}].conditions must not be empty`
+            }
+
+            for (const [j, condition] of group.conditions.entries()) {
+                const path = `next_reply[${i}].conditions[${j}]`
+                if (
+                    typeof condition.user_id !== 'string' ||
+                    !/^[\w-]+$/.test(condition.user_id)
+                ) {
+                    return `Field ${path}.user_id must be a non-empty platform user ID`
+                }
+
+                if (condition.type === 'message_from_user') {
+                    if (
+                        condition.seconds != null ||
+                        condition.max_wait_seconds != null
+                    ) {
+                        return `Fields seconds and max_wait_seconds are not allowed for ${path} with type message_from_user`
+                    }
+                    continue
+                }
+
+                if (
+                    !Number.isInteger(condition.seconds) ||
+                    Number(condition.seconds) <= 0
+                ) {
+                    return `Field ${path}.seconds must be a positive integer for type no_message_from_user`
+                }
+
+                if (
+                    condition.max_wait_seconds != null &&
+                    (!Number.isInteger(condition.max_wait_seconds) ||
+                        Number(condition.max_wait_seconds) <= 0)
+                ) {
+                    return `Field ${path}.max_wait_seconds must be a positive integer`
+                }
+
+                if (
+                    condition.user_id === 'all' &&
+                    condition.max_wait_seconds != null
+                ) {
+                    return `Field ${path}.max_wait_seconds is not allowed when user_id is all`
+                }
+            }
+        }
     }
 
     return undefined

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -475,23 +475,20 @@ function createReplyTools(
                                         'Condition type. message_from_user means a specific user sends a new message. no_message_from_user means no new messages arrive from a target user for a period of time. Use user_id="all" to mean no one sends any new message.'
                                 },
                                 seconds: {
-                                    type: 'number',
+                                    type: 'integer',
                                     minimum: 1,
-                                    multipleOf: 1,
                                     description:
                                         'Waiting time in seconds. Required for no_message_from_user. When user_id is all, counting starts immediately. Otherwise, counting starts only after the target user sends the first new message.'
                                 },
                                 user_id: {
                                     type: 'string',
-                                    minLength: 1,
                                     pattern: '^[\\w-]+$',
                                     description:
                                         'Platform user ID of the target user. Required for message_from_user and no_message_from_user. Use all to mean any user.'
                                 },
                                 max_wait_seconds: {
-                                    type: 'number',
+                                    type: 'integer',
                                     minimum: 1,
-                                    multipleOf: 1,
                                     description:
                                         'Maximum total waiting time in seconds. Optional only for no_message_from_user when user_id is not all. Counting starts after the current turn finishes and this next_reply is registered, and the trigger fires when the limit is reached even if the user never sends the first message.'
                                 }
@@ -2646,7 +2643,7 @@ function getReplyToolInputError(
 
                 if (
                     !Number.isInteger(condition.seconds) ||
-                    Number(condition.seconds) <= 0
+                    condition.seconds <= 0
                 ) {
                     return `Field ${path}.seconds must be a positive integer for type no_message_from_user`
                 }
@@ -2654,7 +2651,7 @@ function getReplyToolInputError(
                 if (
                     condition.max_wait_seconds != null &&
                     (!Number.isInteger(condition.max_wait_seconds) ||
-                        Number(condition.max_wait_seconds) <= 0)
+                        condition.max_wait_seconds <= 0)
                 ) {
                     return `Field ${path}.max_wait_seconds must be a positive integer`
                 }

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -2597,12 +2597,36 @@ function getReplyToolInputError(
         Array.isArray(args.next_reply)
     ) {
         for (const [i, group] of args.next_reply.entries()) {
+            if (
+                !group ||
+                typeof group !== 'object' ||
+                Array.isArray(group) ||
+                !Array.isArray(group.conditions)
+            ) {
+                return `Field next_reply[${i}] must contain a conditions array`
+            }
+
             if (group.conditions.length < 1) {
                 return `Field next_reply[${i}].conditions must not be empty`
             }
 
             for (const [j, condition] of group.conditions.entries()) {
                 const path = `next_reply[${i}].conditions[${j}]`
+                if (
+                    !condition ||
+                    typeof condition !== 'object' ||
+                    Array.isArray(condition)
+                ) {
+                    return `Field ${path} must be an object`
+                }
+
+                if (
+                    condition.type !== 'message_from_user' &&
+                    condition.type !== 'no_message_from_user'
+                ) {
+                    return `Field ${path}.type must be message_from_user or no_message_from_user`
+                }
+
                 if (
                     typeof condition.user_id !== 'string' ||
                     !/^[\w-]+$/.test(condition.user_id)

--- a/src/utils/triggers.ts
+++ b/src/utils/triggers.ts
@@ -35,22 +35,24 @@ export function extractNextReplyReasons(response: string): string[] {
         }
 
         if (type === 'no_message_from_user') {
-            const seconds = Number.parseInt(
-                attributes.match(/\bseconds\s*=\s*['"]([^'"]+)['"]/i)?.[1] ?? '',
-                10
-            )
+            const secondsRaw =
+                attributes.match(/\bseconds\s*=\s*['"]([^'"]+)['"]/i)?.[1] ?? ''
+            const seconds = /^\d+$/.test(secondsRaw)
+                ? Number.parseInt(secondsRaw, 10)
+                : 0
             const userId = attributes.match(/\buser_id\s*=\s*['"]([^'"]+)['"]/i)?.[1]
-            const maxWaitSeconds = Number.parseInt(
+            const maxWaitSecondsRaw =
                 attributes.match(
                     /\bmax_wait_seconds\s*=\s*['"]([^'"]+)['"]/i
-                )?.[1] ?? '',
-                10
-            )
-            if (Number.isFinite(seconds) && seconds > 0 && userId?.trim()) {
+                )?.[1] ?? ''
+            const maxWaitSeconds = /^\d+$/.test(maxWaitSecondsRaw)
+                ? Number.parseInt(maxWaitSecondsRaw, 10)
+                : 0
+            if (seconds > 0 && userId?.trim()) {
                 token =
                     userId.trim() === 'all'
                         ? `time_${seconds}s`
-                        : Number.isFinite(maxWaitSeconds) && maxWaitSeconds > 0
+                        : maxWaitSeconds > 0
                           ? `time_${seconds}s_id_${userId.trim()}_max_${maxWaitSeconds}s`
                           : `time_${seconds}s_id_${userId.trim()}`
             }
@@ -74,7 +76,7 @@ export function extractNextReplyReasons(response: string): string[] {
         }
     }
 
-    return reasons
+    return reasons.length > 0 ? [reasons.join('|')] : []
 }
 
 export interface WakeUpReplyTag {
@@ -199,17 +201,15 @@ export function parseNextReplyReason(
     const groups: PendingNextReplyConditionGroup[] = []
 
     for (const branch of rawReason.split('|').map((it) => it.trim())) {
-        if (!branch) continue
+        if (!branch) return []
 
-        const predicates = branch
-            .split('&')
-            .map((it) => parseNextReplyToken(it))
-            .filter((it): it is NextReplyPredicate => it != null)
+        const tokens = branch.split('&')
+        const predicates = tokens.map((it) => parseNextReplyToken(it))
 
-        if (predicates.length < 1) continue
+        if (predicates.some((it) => it == null)) return []
 
         groups.push({
-            predicates,
+            predicates: predicates as NextReplyPredicate[],
             naturalReason: predicates
                 .map((predicate) => {
                     if (predicate.type === 'time_id') {
@@ -273,7 +273,9 @@ export function evaluateNextReplyGroup(
         }
 
         const lastMessageTimeByUserId =
-            info.messageTimestampsByUserId?.[predicate.userId] ?? 0
+            predicate.userId === 'all'
+                ? info.lastUserMessageTime
+                : (info.messageTimestampsByUserId?.[predicate.userId] ?? 0)
         return lastMessageTimeByUserId >= sentAt
     })
 }

--- a/src/utils/triggers.ts
+++ b/src/utils/triggers.ts
@@ -203,8 +203,9 @@ export function parseNextReplyReason(
     for (const branch of rawReason.split('|').map((it) => it.trim())) {
         if (!branch) return []
 
-        const tokens = branch.split('&')
-        const predicates = tokens.map((it) => parseNextReplyToken(it))
+        const predicates = branch
+            .split('&')
+            .map((it) => parseNextReplyToken(it))
 
         if (predicates.some((it) => it == null)) return []
 


### PR DESCRIPTION
## 变更内容

- 完善 `next_reply` 工具 Schema 和运行时参数校验，明确正整数、用户 ID及条件组合要求。
- 无效 AND 条件会拒绝整条表达式，不再静默删除错误条件并放宽触发范围。
- 修复多个条件组只保留最后一组的问题，恢复文档约定的组间 OR 语义。
- XML 秒数只接受完整正整数，避免小数或尾随字符被截断。
- 使 `message_from_user` 的 `user_id="all"` 按文档语义匹配任意用户。

## 验证

- `yarn tsc --noEmit`
- `yarn fast-build`
- `git diff --check`
- 定点验证 AND 拒绝、OR 合并、XML 小数拒绝和 `all` 用户匹配行为


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for automated reply conditions, including required user identifiers, valid identifier formatting, non-empty conditions, and positive whole-number wait times.
  - Prevented unsupported wait-time settings for user-message conditions and group-wide user selections.
  - Improved handling of invalid or incomplete reply-condition details to ensure they are rejected consistently.
  - Standardized extracted reply reasons into a consistent pipe-delimited format.
  - Improved group-wide reply timing evaluation based on the latest user message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->