### PR TITLE
refactor: 去重 next_reply 参数校验

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -1884,10 +1884,18 @@ Reply again using valid XML output with <message> tags.`
             return
         } catch (e) {
             if (signal?.aborted) return
+            const retry =
+                idx < 1 && String(e).includes('Failed to parse response')
             if (e instanceof ReplyToolError) {
-                logger.warn(REPLY_TOOL_ERROR_MESSAGE, e)
+                logger.warn(
+                    REPLY_TOOL_ERROR_MESSAGE +
+                        (retry
+                            ? '已将错误反馈给模型，尝试在当前轮次重新生成。'
+                            : ''),
+                    e
+                )
             }
-            if (idx < 1 && String(e).includes('Failed to parse response')) {
+            if (retry) {
                 err = e
                 logger.warn('model response failed, retry once', e)
                 continue

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -2614,43 +2614,8 @@ function getReplyToolInputError(
         Array.isArray(args.next_reply)
     ) {
         for (const [i, group] of args.next_reply.entries()) {
-            if (
-                !group ||
-                typeof group !== 'object' ||
-                Array.isArray(group) ||
-                !Array.isArray(group.conditions)
-            ) {
-                return `Field next_reply[${i}] must contain a conditions array`
-            }
-
-            if (group.conditions.length < 1) {
-                return `Field next_reply[${i}].conditions must not be empty`
-            }
-
             for (const [j, condition] of group.conditions.entries()) {
                 const path = `next_reply[${i}].conditions[${j}]`
-                if (
-                    !condition ||
-                    typeof condition !== 'object' ||
-                    Array.isArray(condition)
-                ) {
-                    return `Field ${path} must be an object`
-                }
-
-                if (
-                    condition.type !== 'message_from_user' &&
-                    condition.type !== 'no_message_from_user'
-                ) {
-                    return `Field ${path}.type must be message_from_user or no_message_from_user`
-                }
-
-                if (
-                    typeof condition.user_id !== 'string' ||
-                    !/^[\w-]+$/.test(condition.user_id)
-                ) {
-                    return `Field ${path}.user_id must be a non-empty platform user ID`
-                }
-
                 if (condition.type === 'message_from_user') {
                     if (
                         condition.seconds != null ||
@@ -2661,19 +2626,8 @@ function getReplyToolInputError(
                     continue
                 }
 
-                if (
-                    !Number.isInteger(condition.seconds) ||
-                    condition.seconds <= 0
-                ) {
-                    return `Field ${path}.seconds must be a positive integer for type no_message_from_user`
-                }
-
-                if (
-                    condition.max_wait_seconds != null &&
-                    (!Number.isInteger(condition.max_wait_seconds) ||
-                        condition.max_wait_seconds <= 0)
-                ) {
-                    return `Field ${path}.max_wait_seconds must be a positive integer`
+                if (condition.seconds == null) {
+                    return `Field ${path}.seconds is required for type no_message_from_user`
                 }
 
                 if (

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -56,7 +56,9 @@ let logger: Logger
 
 type ParsedResponse = Awaited<ReturnType<typeof parseResponse>>
 type RuntimeConfig = Config & (GuildConfig | PrivateConfig)
-type StreamedParsedResponseChunk = StreamedModelResponseChunk<ParsedResponse>
+type StreamedParsedResponseChunk = StreamedModelResponseChunk<ParsedResponse> & {
+    nextReplyReasons: string[]
+}
 
 class ReplyToolError extends Error {}
 
@@ -1092,6 +1094,11 @@ async function parseResponseContent(
         )
     }
 
+    // Validate before parsing side effects and outside the intermediate fallback.
+    const nextReplyReasons = toolState
+        ? toolState.nextReplyReasons
+        : extractNextReplyReasons(responseContent)
+
     if (
         !toolState &&
         isIntermediate &&
@@ -1107,6 +1114,7 @@ async function parseResponseContent(
             responseMessage,
             responseContent: renderedContent,
             toolCalls: calls,
+            nextReplyReasons,
             parsedResponse: {
                 elements: [],
                 rawMessage: responseContent,
@@ -1167,6 +1175,7 @@ async function parseResponseContent(
         responseMessage,
         responseContent: renderedContent,
         toolCalls: calls,
+        nextReplyReasons,
         parsedResponse
     }
 }
@@ -1886,21 +1895,23 @@ Reply again using valid XML output with <message> tags.`
             if (signal?.aborted) return
             const retry =
                 idx < 1 && String(e).includes('Failed to parse response')
-            if (e instanceof ReplyToolError) {
-                logger.warn(
-                    REPLY_TOOL_ERROR_MESSAGE +
-                        (retry
-                            ? '已将错误反馈给模型，尝试在当前轮次重新生成。'
-                            : ''),
-                    e
-                )
-            }
             if (retry) {
                 err = e
-                logger.warn('model response failed, retry once', e)
+                logger.warn(
+                    (e instanceof ReplyToolError
+                        ? REPLY_TOOL_ERROR_MESSAGE
+                        : '模型回复格式有误，本次回复已拦截。') +
+                        '已将错误反馈给模型，尝试在当前轮次重新生成。',
+                    e
+                )
                 continue
             }
-            logger.error('model requests failed', e)
+            logger.error(
+                e instanceof ReplyToolError
+                    ? REPLY_TOOL_ERROR_MESSAGE
+                    : 'model requests failed',
+                e
+            )
             throw e
         }
     }
@@ -2334,20 +2345,7 @@ export async function apply(ctx: Context, config: Config) {
                         hasNonEmptyReplies = true
                     }
 
-                    if (
-                        copyOfConfig.experimentalToolCallReply &&
-                        chunk.toolCalls
-                    ) {
-                        const toolState = parseReplyTools(
-                            copyOfConfig,
-                            chunk.toolCalls
-                        )
-                        nextReplyReasons.push(...toolState.nextReplyReasons)
-                    } else {
-                        nextReplyReasons.push(
-                            ...extractNextReplyReasons(chunk.responseContent)
-                        )
-                    }
+                    nextReplyReasons.push(...chunk.nextReplyReasons)
 
                     const sendResult = await handleParsedResponseChunk(
                         session,

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -56,9 +56,10 @@ let logger: Logger
 
 type ParsedResponse = Awaited<ReturnType<typeof parseResponse>>
 type RuntimeConfig = Config & (GuildConfig | PrivateConfig)
-type StreamedParsedResponseChunk = StreamedModelResponseChunk<ParsedResponse> & {
-    nextReplyReasons: string[]
-}
+type StreamedParsedResponseChunk =
+    StreamedModelResponseChunk<ParsedResponse> & {
+        nextReplyReasons: string[]
+    }
 
 class ReplyToolError extends Error {}
 

--- a/src/utils/triggers.ts
+++ b/src/utils/triggers.ts
@@ -26,7 +26,9 @@ export function extractNextReplyReasons(response: string): string[] {
         }
 
         const type = attributes.match(/\btype\s*=\s*['"]([^'"]+)['"]/i)?.[1]
-        const userId = attributes.match(/\buser_id\s*=\s*['"]([^'"]+)['"]/i)?.[1]
+        const userId = attributes.match(
+            /\buser_id\s*=\s*['"]([^'"]+)['"]/i
+        )?.[1]
         const secondsRaw = attributes.match(
             /\bseconds\s*=\s*['"]([^'"]*)['"]/i
         )?.[1]

--- a/src/utils/triggers.ts
+++ b/src/utils/triggers.ts
@@ -47,13 +47,14 @@ export function extractNextReplyReasons(response: string): string[] {
         }
 
         if (type === 'no_message_from_user') {
-            const seconds = secondsRaw && /^\d+$/.test(secondsRaw)
-                ? Number.parseInt(secondsRaw, 10)
-                : 0
+            const seconds =
+                secondsRaw && /^\d+$/.test(secondsRaw)
+                    ? Number.parseInt(secondsRaw, 10)
+                    : 0
             const maxWaitSeconds =
                 maxWaitSecondsRaw && /^\d+$/.test(maxWaitSecondsRaw)
-                ? Number.parseInt(maxWaitSecondsRaw, 10)
-                : 0
+                    ? Number.parseInt(maxWaitSecondsRaw, 10)
+                    : 0
             if (
                 seconds > 0 &&
                 userId != null &&

--- a/src/utils/triggers.ts
+++ b/src/utils/triggers.ts
@@ -28,10 +28,10 @@ export function extractNextReplyReasons(response: string): string[] {
         const type = attributes.match(/\btype\s*=\s*['"]([^'"]+)['"]/i)?.[1]
         const userId = attributes.match(/\buser_id\s*=\s*['"]([^'"]+)['"]/i)?.[1]
         const secondsRaw = attributes.match(
-            /\bseconds\s*=\s*['"]([^'"]+)['"]/i
+            /\bseconds\s*=\s*['"]([^'"]*)['"]/i
         )?.[1]
         const maxWaitSecondsRaw = attributes.match(
-            /\bmax_wait_seconds\s*=\s*['"]([^'"]+)['"]/i
+            /\bmax_wait_seconds\s*=\s*['"]([^'"]*)['"]/i
         )?.[1]
 
         let token: string | undefined
@@ -56,9 +56,11 @@ export function extractNextReplyReasons(response: string): string[] {
                     ? Number.parseInt(maxWaitSecondsRaw, 10)
                     : 0
             if (
+                Number.isSafeInteger(seconds) &&
                 seconds > 0 &&
                 userId != null &&
                 /^[\w-]+$/.test(userId) &&
+                Number.isSafeInteger(maxWaitSeconds) &&
                 (maxWaitSecondsRaw == null || maxWaitSeconds > 0) &&
                 (userId !== 'all' || maxWaitSecondsRaw == null)
             ) {

--- a/src/utils/triggers.ts
+++ b/src/utils/triggers.ts
@@ -16,50 +16,64 @@ export function extractNextReplyReasons(response: string): string[] {
         const attributes = match[1] ?? ''
         const reason = attributes.match(/\breason\s*=\s*['"]([^'"]+)['"]/i)?.[1]
         if (reason?.trim()) {
+            if (parseNextReplyReason(reason).length < 1) {
+                throw new Error(
+                    `Failed to parse response: invalid <next_reply reason="${reason}" />`
+                )
+            }
             reasons.push(reason.trim())
             continue
         }
 
         const type = attributes.match(/\btype\s*=\s*['"]([^'"]+)['"]/i)?.[1]
-        if (!type?.trim()) {
-            continue
-        }
+        const userId = attributes.match(/\buser_id\s*=\s*['"]([^'"]+)['"]/i)?.[1]
+        const secondsRaw = attributes.match(
+            /\bseconds\s*=\s*['"]([^'"]+)['"]/i
+        )?.[1]
+        const maxWaitSecondsRaw = attributes.match(
+            /\bmax_wait_seconds\s*=\s*['"]([^'"]+)['"]/i
+        )?.[1]
 
         let token: string | undefined
 
-        if (type === 'message_from_user') {
-            const userId = attributes.match(/\buser_id\s*=\s*['"]([^'"]+)['"]/i)?.[1]
-            if (userId?.trim()) {
-                token = `id_${userId.trim()}`
-            }
+        if (
+            type === 'message_from_user' &&
+            userId != null &&
+            /^[\w-]+$/.test(userId) &&
+            secondsRaw == null &&
+            maxWaitSecondsRaw == null
+        ) {
+            token = `id_${userId}`
         }
 
         if (type === 'no_message_from_user') {
-            const secondsRaw =
-                attributes.match(/\bseconds\s*=\s*['"]([^'"]+)['"]/i)?.[1] ?? ''
-            const seconds = /^\d+$/.test(secondsRaw)
+            const seconds = secondsRaw && /^\d+$/.test(secondsRaw)
                 ? Number.parseInt(secondsRaw, 10)
                 : 0
-            const userId = attributes.match(/\buser_id\s*=\s*['"]([^'"]+)['"]/i)?.[1]
-            const maxWaitSecondsRaw =
-                attributes.match(
-                    /\bmax_wait_seconds\s*=\s*['"]([^'"]+)['"]/i
-                )?.[1] ?? ''
-            const maxWaitSeconds = /^\d+$/.test(maxWaitSecondsRaw)
+            const maxWaitSeconds =
+                maxWaitSecondsRaw && /^\d+$/.test(maxWaitSecondsRaw)
                 ? Number.parseInt(maxWaitSecondsRaw, 10)
                 : 0
-            if (seconds > 0 && userId?.trim()) {
+            if (
+                seconds > 0 &&
+                userId != null &&
+                /^[\w-]+$/.test(userId) &&
+                (maxWaitSecondsRaw == null || maxWaitSeconds > 0) &&
+                (userId !== 'all' || maxWaitSecondsRaw == null)
+            ) {
                 token =
-                    userId.trim() === 'all'
+                    userId === 'all'
                         ? `time_${seconds}s`
                         : maxWaitSeconds > 0
-                          ? `time_${seconds}s_id_${userId.trim()}_max_${maxWaitSeconds}s`
-                          : `time_${seconds}s_id_${userId.trim()}`
+                          ? `time_${seconds}s_id_${userId}_max_${maxWaitSeconds}s`
+                          : `time_${seconds}s_id_${userId}`
             }
         }
 
         if (!token) {
-            continue
+            throw new Error(
+                `Failed to parse response: invalid <next_reply${attributes} />`
+            )
         }
 
         const group =


### PR DESCRIPTION
## 变更内容

- 删除 `next_reply` 业务校验中已由完整工具 Schema 覆盖的对象形状、枚举、类型、正整数和用户 ID格式检查。
- 保留 Schema 无法直接表达的跨字段规则：
  - `message_from_user` 不允许携带时间参数。
  - `no_message_from_user` 必须提供 `seconds`。
  - `user_id="all"` 时不允许 `max_wait_seconds`。
- XML 回复中的非法 `next_reply` 不再被静默丢弃，而是在发送消息前使整次回复失败并进入纠错重试，避免 AND 条件被意外放宽。
- 外层确实进行纠错重试时，Koishi 日志会追加“已将错误反馈给模型，尝试在当前轮次重新生成。”。

## 背景

PR #123 合并后，所有 `character_reply` 都会先通过 `reply.invoke()` 完成完整 Schema 校验，再进入 `getReplyToolInputError()` 的业务校验。因此 PR #122 为独立运行而添加的结构检查已成为重复代码。

## 验证

- `yarn tsc --noEmit`
- `yarn fast-build`
- `git diff --check`
- 定点验证合法 `next_reply` 及非法秒数、最大等待时间、类型和字段组合


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for reply scheduling settings, including trigger types, user identifiers, and timing values.
  - Invalid reply instructions now produce clear errors instead of being silently ignored.
  - Prevented unsupported combinations of message-based triggers and wait-time settings.
  - Improved response handling so follow-up reasons remain consistent during streamed replies.
  - Retry warnings now distinguish reply-tool errors from general response-format errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->