### PR TITLE
feat: 添加工具调用进度消息开关

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,7 @@ export interface Config extends ChatLunaPlugin.Config {
     configs: Record<string, GuildConfig>
 
     defaultPreset: string
+    toolCallProgressMessage: boolean
     isNickname: boolean
     isNickNameWithContent: boolean
 
@@ -120,6 +121,9 @@ const commonModelConfig = Schema.object({
     .collapse()
 
 const commonChatBehaviorConfig = Schema.object({
+    toolCallProgressMessage: Schema.boolean()
+        .description('是否要求模型在耗时工具调用时发送进度消息')
+        .default(true),
     splitVoice: Schema.boolean().description('是否分段发送语音').default(false),
     isNickname: Schema.boolean()
         .description('允许 bot 配置中的昵称引发回复')

--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -783,9 +783,14 @@ function formatReplyUserPrompt(session: Session, config: RuntimeConfig) {
 
     if (config.experimentalToolCallReply && config.toolCalling) {
         tips.push(
-            'All user-visible reply content must be sent through `character_reply`. Do not end the turn with plain text outside this tool.',
-            'Before calling time-consuming tools (such as searching), send a progress update to the user with `character_reply` and call the time-consuming tool in the same assistant response. Never call `character_reply` with `is_final=false` alone. Quick tools that finish almost instantly, such as reading a voice message, do not need this.'
+            'All user-visible reply content must be sent through `character_reply`. Do not end the turn with plain text outside this tool.'
         )
+
+        if (config.toolCallProgressMessage) {
+            tips.push(
+                'Before calling time-consuming tools (such as searching), send a progress update to the user with `character_reply` and call the time-consuming tool in the same assistant response. Never call `character_reply` with `is_final=false` alone. Quick tools that finish almost instantly, such as reading a voice message, do not need this.'
+            )
+        }
 
         if (config.toolCallReplyStatusTag) {
             tips.push(

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export interface GuildConfig {
     messageActivityScoreUpperLimit: number
     enableActivityScoreTrigger: boolean
     maxTokens: number
+    toolCallProgressMessage: boolean
     isNickname: boolean
     isNickNameWithContent: boolean
     isForceMute: boolean


### PR DESCRIPTION
## 变更内容

- 在私聊与群聊的“行为”配置首位新增工具调用进度消息开关，默认开启
- 关闭开关后，不再向模型注入耗时工具调用前发送进度消息的要求
- 保留通过 `character_reply` 发送用户可见回复的原有约束

## 验证

- `yarn tsc --noEmit`
- `yarn fast-build`
- 同步至本地 Koishi 后重启容器，构建产物哈希一致


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control whether the assistant is prompted to send progress updates before lengthy tool actions.
  * Progress-update guidance is now enabled by default and can be adjusted through chat behavior settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->