### PR TITLE
fix: 修复历史满载时状态漏存

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -2087,7 +2087,6 @@ export async function apply(ctx: Context, config: Config) {
             }
 
             const latestMessages = service.getMessages(key) ?? messages
-            const count = latestMessages.length
             const temp = await service.getTemp(session, latestMessages)
             const focusMessage = latestMessages[latestMessages.length - 1]
 
@@ -2241,13 +2240,10 @@ export async function apply(ctx: Context, config: Config) {
             }
 
             const persistedMessages = service.getMessages(key) ?? latestMessages
-            if (persistedMessages.length > count) {
+            const anchor = persistedMessages[persistedMessages.length - 1]
+            if (anchor && anchor !== focusMessage) {
                 temp.status = latestStatus
-                await service.persistStatus(
-                    session,
-                    latestStatus,
-                    persistedMessages[persistedMessages.length - 1]
-                )
+                await service.persistStatus(session, latestStatus, anchor)
             }
 
             temp.completionMessages.push(persistedHumanMessage)


### PR DESCRIPTION
## 变更说明

- 将 status 回写条件从消息数组长度增长改为队尾锚点变化。
- 修复历史达到 `maxMessages` 后，新消息入队但数组长度不变导致的状态漏存。
- 保留无新消息时不回写状态的原有行为。

## 验证

- `yarn tsc --noEmit`
- `yarn fast-build`
- `git diff --check`
- 同步本地 Koishi 后校验构建产物哈希一致，并确认容器正常启动。

Fixes #113
