### PR TITLE
fix: 限制角色回复参数纠错次数

### DIFF
--- a/src/plugins/chat.ts
+++ b/src/plugins/chat.ts
@@ -1229,6 +1229,7 @@ async function* streamAgentResponseContents(
     }:${session.isDirect ? session.userId : (session.guildId ?? session.channelId)}`
 
     let finalReply = false
+    let retried = false
     let reply: StructuredTool | undefined
 
     const responseStream = chain.stream(
@@ -1262,6 +1263,8 @@ async function* streamAgentResponseContents(
                 await validateReplyToolCalls(reply, calls)
             } catch (err) {
                 if (!(err instanceof ReplyToolError)) throw err
+                if (retried) throw err
+                retried = true
                 logger.warn(
                     REPLY_TOOL_ERROR_MESSAGE +
                         '已将错误反馈给模型，尝试在当前轮次重新生成。',


### PR DESCRIPTION
## 变更内容

- 同一 Agent 流首次生成非法 `character_reply` 时，仍允许模型在当前轮次纠错。
- 当前轮次第二次生成非法参数时直接抛出错误，交由原有的整体重试机制处理。
- 避免能力不足或结构化输出异常的模型在 Agent 内持续纠错，长时间占用回复锁。

## 问题原因

PR #123 将非法工具调用改为在同一 Agent 流中使用 `continue` 等待模型纠正，但插件侧没有限制纠错次数。模型持续生成非法参数时，错误无法进入外层仅重试一次的流程。

## 验证

- `yarn tsc --noEmit`
- `yarn fast-build`
- `git diff --check upstream/main...HEAD`
- 同步本地源码并重启 Koishi，构建产物 SHA-256 一致


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated retries when character reply validation fails during streaming.
  * Subsequent validation failures now surface as errors instead of retrying indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->