### PR TITLE
chore: 发布 0.0.234

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-character",
     "description": "Let the large language model play a role, disguise as a group friend",
-    "version": "0.0.233",
+    "version": "0.0.234",
     "type": "module",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",


### PR DESCRIPTION
## 变更

- 将版本号从 `0.0.233` 提升至 `0.0.234`
- 触发合并到 `main` 后的 npm 发布流程

## 验证

- `tsc --noEmit`
- `yarn fast-build`
